### PR TITLE
Implement french republic calendar

### DIFF
--- a/src/main/java/org/threeten/extra/chrono/FrenchRepublicChronology.java
+++ b/src/main/java/org/threeten/extra/chrono/FrenchRepublicChronology.java
@@ -306,19 +306,20 @@ public final class FrenchRepublicChronology
 
     @Override
     public ValueRange range(ChronoField field) {
-        if (field == DAY_OF_WEEK)
+        if (field == DAY_OF_WEEK) {
             return DOW_RANGE;
-        else if (WeekFields.ISO.dayOfWeek().equals(field))
+        } else if (WeekFields.ISO.dayOfWeek().equals(field)) {
             return DOW_RANGE;
-        else if (field == ALIGNED_WEEK_OF_MONTH)
+        } else if (field == ALIGNED_WEEK_OF_MONTH) {
             return ALIGNED_WOM_RANGE;
+        }
         return super.range(field);
     }
     
     //-----------------------------------------------------------------------
     @Override
     public int prolepticYear(Era era, int yearOfEra) {
-        if (! (era instanceof FrenchRepublicEra)) {
+        if (!(era instanceof FrenchRepublicEra)) {
             throw new ClassCastException("Era must be FrenchRepublicEra");
         }
         return (era == FrenchRepublicEra.REPUBLICAN ? yearOfEra : 1 - yearOfEra);

--- a/src/main/java/org/threeten/extra/chrono/FrenchRepublicChronology.java
+++ b/src/main/java/org/threeten/extra/chrono/FrenchRepublicChronology.java
@@ -1,0 +1,343 @@
+/*
+ * Copyright (c) 2007-present, Stephen Colebourne & Michael Nascimento Santos
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *  * Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ *  * Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ *  * Neither the name of JSR-310 nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.threeten.extra.chrono;
+
+import java.io.Serializable;
+import java.time.Clock;
+import java.time.DateTimeException;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.chrono.ChronoLocalDateTime;
+import java.time.chrono.ChronoZonedDateTime;
+import java.time.chrono.Era;
+import java.time.format.ResolverStyle;
+import java.time.temporal.ChronoField;
+import static java.time.temporal.ChronoField.ALIGNED_WEEK_OF_MONTH;
+import static java.time.temporal.ChronoField.DAY_OF_WEEK;
+import java.time.temporal.TemporalAccessor;
+import java.time.temporal.TemporalField;
+import java.time.temporal.ValueRange;
+import java.time.temporal.WeekFields;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+/**
+
+ */
+public final class FrenchRepublicChronology
+        extends AbstractNileChronology
+        implements Serializable {
+
+    /**
+     * Singleton instance for the FrenchRepublic chronology.
+     */
+    public static final FrenchRepublicChronology INSTANCE = new FrenchRepublicChronology();
+
+    /**
+     * Serialization version.
+     */
+    private static final long serialVersionUID = 7291205177830286973L;
+
+    /**
+     * Range of days of week.
+     */
+    static final ValueRange DOW_RANGE = ValueRange.of(1, 10);
+    /**
+     * Range of weeks.
+     */
+    static final ValueRange ALIGNED_WOM_RANGE = ValueRange.of(1, 1, 3);
+    
+    /**
+     * Private constructor, that is public to satisfy the {@code ServiceLoader}.
+     * @deprecated Use the singleton {@link #INSTANCE} instead.
+     */
+    @Deprecated
+    public FrenchRepublicChronology() {
+    }
+
+    /**
+     * Resolve singleton.
+     *
+     * @return the singleton instance, not null
+     */
+    private Object readResolve() {
+        return INSTANCE;
+    }
+
+    //-----------------------------------------------------------------------
+    /**
+     * Gets the ID of the chronology - 'FrenchRepublic'.
+     * <p>
+     * The ID uniquely identifies the {@code Chronology}.
+     * It can be used to lookup the {@code Chronology} using {@link #of(String)}.
+     *
+     * @return the chronology ID - 'FrenchRepublic'
+     * @see #getCalendarType()
+     */
+    @Override
+    public String getId() {
+        return "French Republican";
+    }
+
+    /**
+     * Gets the calendar type of the underlying calendar system - 'frenchrepublican'.
+     * <p>
+     * The <em>Unicode Locale Data Markup Language (LDML)</em> specification
+     * does not define an identifier for the French Revolutionary calendar, but
+     * were it to do so, 'frenchrepublican' is likely to be chosen.
+     *
+     * @return the calendar system type - 'frenchrepublican'
+     * @see #getId()
+     */
+    @Override
+    public String getCalendarType() {
+        return "frenchrepublican";
+    }
+
+    //-----------------------------------------------------------------------
+    /**
+     * Obtains a local date in FrenchRepublic calendar system from the
+     * era, year-of-era, month-of-year and day-of-month fields.
+     *
+     * @param era  the FrenchRepublic era, not null
+     * @param yearOfEra  the year-of-era
+     * @param month  the month-of-year
+     * @param dayOfMonth  the day-of-month
+     * @return the FrenchRepublic local date, not null
+     * @throws DateTimeException if unable to create the date
+     * @throws ClassCastException if the {@code era} is not a {@code FrenchRepublicEra}
+     */
+    @Override
+    public FrenchRepublicDate date(Era era, int yearOfEra, int month, int dayOfMonth) {
+        return date(prolepticYear(era, yearOfEra), month, dayOfMonth);
+    }
+
+    /**
+     * Obtains a local date in FrenchRepublic calendar system from the
+     * proleptic-year, month-of-year and day-of-month fields.
+     *
+     * @param prolepticYear  the proleptic-year
+     * @param month  the month-of-year
+     * @param dayOfMonth  the day-of-month
+     * @return the FrenchRepublic local date, not null
+     * @throws DateTimeException if unable to create the date
+     */
+    @Override
+    public FrenchRepublicDate date(int prolepticYear, int month, int dayOfMonth) {
+        return FrenchRepublicDate.of(prolepticYear, month, dayOfMonth);
+    }
+
+    /**
+     * Obtains a local date in FrenchRepublic calendar system from the
+     * era, year-of-era and day-of-year fields.
+     *
+     * @param era  the FrenchRepublic era, not null
+     * @param yearOfEra  the year-of-era
+     * @param dayOfYear  the day-of-year
+     * @return the FrenchRepublic local date, not null
+     * @throws DateTimeException if unable to create the date
+     * @throws ClassCastException if the {@code era} is not a {@code FrenchRepublicEra}
+     */
+    @Override
+    public FrenchRepublicDate dateYearDay(Era era, int yearOfEra, int dayOfYear) {
+        return dateYearDay(prolepticYear(era, yearOfEra), dayOfYear);
+    }
+
+    /**
+     * Obtains a local date in FrenchRepublic calendar system from the
+     * proleptic-year and day-of-year fields.
+     *
+     * @param prolepticYear  the proleptic-year
+     * @param dayOfYear  the day-of-year
+     * @return the FrenchRepublic local date, not null
+     * @throws DateTimeException if unable to create the date
+     */
+    @Override
+    public FrenchRepublicDate dateYearDay(int prolepticYear, int dayOfYear) {
+        return FrenchRepublicDate.ofYearDay(prolepticYear, dayOfYear);
+    }
+
+    /**
+     * Obtains a local date in the FrenchRepublic calendar system from the epoch-day.
+     *
+     * @param epochDay  the epoch day
+     * @return the FrenchRepublic local date, not null
+     * @throws DateTimeException if unable to create the date
+     */
+    @Override  // override with covariant return type
+    public FrenchRepublicDate dateEpochDay(long epochDay) {
+        return FrenchRepublicDate.ofEpochDay(epochDay);
+    }
+
+    //-------------------------------------------------------------------------
+    /**
+     * Obtains the current FrenchRepublic local date from the system clock in the default time-zone.
+     * <p>
+     * This will query the {@link Clock#systemDefaultZone() system clock} in the default
+     * time-zone to obtain the current date.
+     * <p>
+     * Using this method will prevent the ability to use an alternate clock for testing
+     * because the clock is hard-coded.
+     *
+     * @return the current FrenchRepublic local date using the system clock and default time-zone, not null
+     * @throws DateTimeException if unable to create the date
+     */
+    @Override  // override with covariant return type
+    public FrenchRepublicDate dateNow() {
+        return FrenchRepublicDate.now();
+    }
+
+    /**
+     * Obtains the current FrenchRepublic local date from the system clock in the specified time-zone.
+     * <p>
+     * This will query the {@link Clock#system(ZoneId) system clock} to obtain the current date.
+     * Specifying the time-zone avoids dependence on the default time-zone.
+     * <p>
+     * Using this method will prevent the ability to use an alternate clock for testing
+     * because the clock is hard-coded.
+     *
+     * @param zone the zone ID to use, not null
+     * @return the current FrenchRepublic local date using the system clock, not null
+     * @throws DateTimeException if unable to create the date
+     */
+    @Override  // override with covariant return type
+    public FrenchRepublicDate dateNow(ZoneId zone) {
+        return FrenchRepublicDate.now(zone);
+    }
+
+    /**
+     * Obtains the current FrenchRepublic local date from the specified clock.
+     * <p>
+     * This will query the specified clock to obtain the current date - today.
+     * Using this method allows the use of an alternate clock for testing.
+     * The alternate clock may be introduced using {@link Clock dependency injection}.
+     *
+     * @param clock  the clock to use, not null
+     * @return the current FrenchRepublic local date, not null
+     * @throws DateTimeException if unable to create the date
+     */
+    @Override  // override with covariant return type
+    public FrenchRepublicDate dateNow(Clock clock) {
+        return FrenchRepublicDate.now(clock);
+    }
+
+    //-------------------------------------------------------------------------
+    /**
+     * Obtains a FrenchRepublic local date from another date-time object.
+     *
+     * @param temporal  the date-time object to convert, not null
+     * @return the FrenchRepublic local date, not null
+     * @throws DateTimeException if unable to create the date
+     */
+    @Override
+    public FrenchRepublicDate date(TemporalAccessor temporal) {
+        return FrenchRepublicDate.from(temporal);
+    }
+
+    /**
+     * Obtains a FrenchRepublic local date-time from another date-time object.
+     *
+     * @param temporal  the date-time object to convert, not null
+     * @return the FrenchRepublic local date-time, not null
+     * @throws DateTimeException if unable to create the date-time
+     */
+    @Override
+    @SuppressWarnings("unchecked")
+    public ChronoLocalDateTime<FrenchRepublicDate> localDateTime(TemporalAccessor temporal) {
+        return (ChronoLocalDateTime<FrenchRepublicDate>) super.localDateTime(temporal);
+    }
+
+    /**
+     * Obtains a FrenchRepublic zoned date-time from another date-time object.
+     *
+     * @param temporal  the date-time object to convert, not null
+     * @return the FrenchRepublic zoned date-time, not null
+     * @throws DateTimeException if unable to create the date-time
+     */
+    @Override
+    @SuppressWarnings("unchecked")
+    public ChronoZonedDateTime<FrenchRepublicDate> zonedDateTime(TemporalAccessor temporal) {
+        return (ChronoZonedDateTime<FrenchRepublicDate>) super.zonedDateTime(temporal);
+    }
+
+    /**
+     * Obtains a FrenchRepublic zoned date-time in this chronology from an {@code Instant}.
+     *
+     * @param instant  the instant to create the date-time from, not null
+     * @param zone  the time-zone, not null
+     * @return the FrenchRepublic zoned date-time, not null
+     * @throws DateTimeException if the result exceeds the supported range
+     */
+    @Override
+    @SuppressWarnings("unchecked")
+    public ChronoZonedDateTime<FrenchRepublicDate> zonedDateTime(Instant instant, ZoneId zone) {
+        return (ChronoZonedDateTime<FrenchRepublicDate>) super.zonedDateTime(instant, zone);
+    }
+
+    @Override
+    public ValueRange range(ChronoField field) {
+        if (field == DAY_OF_WEEK)
+            return DOW_RANGE;
+        else if (WeekFields.ISO.dayOfWeek().equals(field))
+            return DOW_RANGE;
+        else if (field == ALIGNED_WEEK_OF_MONTH)
+            return ALIGNED_WOM_RANGE;
+        return super.range(field);
+    }
+    
+    //-----------------------------------------------------------------------
+    @Override
+    public int prolepticYear(Era era, int yearOfEra) {
+        if (! (era instanceof FrenchRepublicEra)) {
+            throw new ClassCastException("Era must be FrenchRepublicEra");
+        }
+        return (era == FrenchRepublicEra.REPUBLICAN ? yearOfEra : 1 - yearOfEra);
+    }
+
+    @Override
+    public FrenchRepublicEra eraOf(int eraValue) {
+        return FrenchRepublicEra.of(eraValue);
+    }
+
+    @Override
+    public List<Era> eras() {
+        return Arrays.<Era>asList(FrenchRepublicEra.values());
+    }
+
+    //-----------------------------------------------------------------------
+    @Override  // override for return type
+    public FrenchRepublicDate resolveDate(Map<TemporalField, Long> fieldValues, ResolverStyle resolverStyle) {
+        return (FrenchRepublicDate) super.resolveDate(fieldValues, resolverStyle);
+    }
+
+}

--- a/src/main/java/org/threeten/extra/chrono/FrenchRepublicChronology.java
+++ b/src/main/java/org/threeten/extra/chrono/FrenchRepublicChronology.java
@@ -76,7 +76,7 @@ public final class FrenchRepublicChronology
      * Range of weeks.
      */
     static final ValueRange ALIGNED_WOM_RANGE = ValueRange.of(1, 1, 3);
-    
+
     /**
      * Private constructor, that is public to satisfy the {@code ServiceLoader}.
      * @deprecated Use the singleton {@link #INSTANCE} instead.
@@ -306,19 +306,18 @@ public final class FrenchRepublicChronology
 
     @Override
     public ValueRange range(ChronoField field) {
-        if (field == DAY_OF_WEEK)
+        if (field == DAY_OF_WEEK) {
             return DOW_RANGE;
-        else if (WeekFields.ISO.dayOfWeek().equals(field))
-            return DOW_RANGE;
-        else if (field == ALIGNED_WEEK_OF_MONTH)
+        } else if (field == ALIGNED_WEEK_OF_MONTH) {
             return ALIGNED_WOM_RANGE;
+        }
         return super.range(field);
     }
-    
+
     //-----------------------------------------------------------------------
     @Override
     public int prolepticYear(Era era, int yearOfEra) {
-        if (! (era instanceof FrenchRepublicEra)) {
+        if (!(era instanceof FrenchRepublicEra)) {
             throw new ClassCastException("Era must be FrenchRepublicEra");
         }
         return (era == FrenchRepublicEra.REPUBLICAN ? yearOfEra : 1 - yearOfEra);

--- a/src/main/java/org/threeten/extra/chrono/FrenchRepublicChronology.java
+++ b/src/main/java/org/threeten/extra/chrono/FrenchRepublicChronology.java
@@ -69,6 +69,10 @@ public final class FrenchRepublicChronology
     private static final long serialVersionUID = 7291205177830286973L;
 
     /**
+     * Empty range
+     */
+    static final ValueRange EMPTY = ValueRange.of(0, 0);
+    /**
      * Range of days of week.
      */
     static final ValueRange DOW_RANGE = ValueRange.of(1, 10);

--- a/src/main/java/org/threeten/extra/chrono/FrenchRepublicDate.java
+++ b/src/main/java/org/threeten/extra/chrono/FrenchRepublicDate.java
@@ -32,6 +32,7 @@
 package org.threeten.extra.chrono;
 
 import static java.time.temporal.ChronoField.DAY_OF_MONTH;
+import static java.time.temporal.ChronoField.DAY_OF_WEEK;
 import static java.time.temporal.ChronoField.DAY_OF_YEAR;
 import static java.time.temporal.ChronoField.EPOCH_DAY;
 import static java.time.temporal.ChronoField.MONTH_OF_YEAR;
@@ -87,8 +88,8 @@ public final class FrenchRepublicDate
      * The days per 4 year cycle.
      */
     private static final int DAYS_PER_CYCLE = (365 * 4) + 1;
-    
-    
+
+
     /**
      * The proleptic year.
      */
@@ -199,19 +200,21 @@ public final class FrenchRepublicDate
 
     @Override
     public ValueRange range(TemporalField field) {
-        if (field.equals(WeekFields.ISO.dayOfWeek()))
+        if (DAY_OF_WEEK.equals(field)) {
             return DOW_RANGE;
+        }
 
         return super.range(field);
-    }    
+    }
 
     @Override
     public long getLong(TemporalField field) {
-        if (field.equals(WeekFields.ISO.dayOfWeek()))
+        if (DAY_OF_WEEK.equals(field)) {
             return day;
+        }
         return super.getLong(field);
     }
-    
+
     @Override
     int getDayOfWeek() {
         return (int) Math.floorMod(day, 10);
@@ -222,8 +225,8 @@ public final class FrenchRepublicDate
         return 10;
     }
 
-    
-    
+
+
     //-----------------------------------------------------------------------
     /**
      * Obtains a {@code FrenchRepublicDate} representing a date in the FrenchRepublic calendar
@@ -291,17 +294,13 @@ public final class FrenchRepublicDate
         FrenchRepublicChronology.YEAR_RANGE.checkValidValue(prolepticYear, YEAR);
         FrenchRepublicChronology.MOY_RANGE.checkValidValue(month, MONTH_OF_YEAR);
         FrenchRepublicChronology.DOM_RANGE.checkValidValue(dayOfMonth, DAY_OF_MONTH);
-        if (month == 13 && dayOfMonth > 5) {
-            if (FrenchRepublicChronology.INSTANCE.isLeapYear(prolepticYear)) {
-                if (dayOfMonth > 6) {
-                    throw new DateTimeException("Invalid date 'Complementary day " + dayOfMonth + "', valid range from 1 to 5, or 1 to 6 in a leap year");
-                }
-            } else {
-                if (dayOfMonth == 6) {
-                    throw new DateTimeException("Invalid date 'Complementary day 6' as '" + prolepticYear + "' is not a leap year");
-                } else {
-                    throw new DateTimeException("Invalid date 'Complementary day " + dayOfMonth + "', valid range from 1 to 5, or 1 to 6 in a leap year");
-                }
+        if (month == 13) {
+            int maxDays = FrenchRepublicChronology.INSTANCE.isLeapYear(prolepticYear) ? 6 : 5;
+            if (dayOfMonth == 6 && maxDays == 5) {
+                throw new DateTimeException("Invalid date 'Complementary day 6' of non-leap year '" + prolepticYear + "'");
+            }
+            if (dayOfMonth > maxDays) {
+                throw new DateTimeException("Invalid date 'Complementary day " + dayOfMonth + " of year '" + prolepticYear + "'");
             }
         }
         return new FrenchRepublicDate(prolepticYear, month, dayOfMonth);
@@ -437,5 +436,5 @@ public final class FrenchRepublicDate
         long year = (long) getProlepticYear();
         long calendarEpochDay = (year * 365) + Math.floorDiv(year, 4) + (getDayOfYear() - 1);
         return calendarEpochDay - 365 - getEpochDayDifference();
-    }    
+    }
 }

--- a/src/main/java/org/threeten/extra/chrono/FrenchRepublicDate.java
+++ b/src/main/java/org/threeten/extra/chrono/FrenchRepublicDate.java
@@ -1,0 +1,441 @@
+/*
+ * Copyright (c) 2007-present, Stephen Colebourne & Michael Nascimento Santos
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *  * Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ *  * Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ *  * Neither the name of JSR-310 nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.threeten.extra.chrono;
+
+import static java.time.temporal.ChronoField.DAY_OF_MONTH;
+import static java.time.temporal.ChronoField.DAY_OF_YEAR;
+import static java.time.temporal.ChronoField.EPOCH_DAY;
+import static java.time.temporal.ChronoField.MONTH_OF_YEAR;
+import static java.time.temporal.ChronoField.YEAR;
+
+import java.io.Serializable;
+import java.time.Clock;
+import java.time.DateTimeException;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.time.ZoneId;
+import java.time.chrono.ChronoLocalDate;
+import java.time.chrono.ChronoLocalDateTime;
+import java.time.chrono.ChronoPeriod;
+import java.time.temporal.ChronoField;
+import java.time.temporal.Temporal;
+import java.time.temporal.TemporalAccessor;
+import java.time.temporal.TemporalAdjuster;
+import java.time.temporal.TemporalAmount;
+import java.time.temporal.TemporalField;
+import java.time.temporal.TemporalQuery;
+import java.time.temporal.TemporalUnit;
+import java.time.temporal.ValueRange;
+import java.time.temporal.WeekFields;
+import static org.threeten.extra.chrono.FrenchRepublicChronology.DOW_RANGE;
+
+/**
+ * A date in the FrenchRepublic calendar system.
+ * <p>
+ * This date operates using the {@linkplain FrenchRepublicChronology FrenchRepublic calendar}.
+ * This calendar system is primarily used in Christian Egypt.
+ * Dates are aligned such that {@code 0001-01-01 (FrenchRepublic)} is {@code 0284-08-29 (ISO)}.
+ *
+ * <h3>Implementation Requirements</h3>
+ * This class is immutable and thread-safe.
+ * <p>
+ * This class must be treated as a value type. Do not synchronize, rely on the
+ * identity hash code or use the distinction between equals() and ==.
+ */
+public final class FrenchRepublicDate
+        extends AbstractNileDate
+        implements ChronoLocalDate, Serializable {
+
+    /**
+     * Serialization version.
+     */
+    private static final long serialVersionUID = -7920528871688876868L;
+    /**
+     * The difference between the ISO and FrenchRepublic epoch day count.
+     */
+    private static final int EPOCH_DAY_DIFFERENCE = 64748;  // MJD values
+    /**
+     * The days per 4 year cycle.
+     */
+    private static final int DAYS_PER_CYCLE = (365 * 4) + 1;
+    
+    
+    /**
+     * The proleptic year.
+     */
+    private final int prolepticYear;
+    /**
+     * The month.
+     */
+    private final short month;
+    /**
+     * The day.
+     */
+    private final short day;
+
+    //-----------------------------------------------------------------------
+    /**
+     * Obtains the current {@code FrenchRepublicDate} from the system clock in the default time-zone.
+     * <p>
+     * This will query the {@link Clock#systemDefaultZone() system clock} in the default
+     * time-zone to obtain the current date.
+     * <p>
+     * Using this method will prevent the ability to use an alternate clock for testing
+     * because the clock is hard-coded.
+     *
+     * @return the current date using the system clock and default time-zone, not null
+     */
+    public static FrenchRepublicDate now() {
+        return now(Clock.systemDefaultZone());
+    }
+
+    /**
+     * Obtains the current {@code FrenchRepublicDate} from the system clock in the specified time-zone.
+     * <p>
+     * This will query the {@link Clock#system(ZoneId) system clock} to obtain the current date.
+     * Specifying the time-zone avoids dependence on the default time-zone.
+     * <p>
+     * Using this method will prevent the ability to use an alternate clock for testing
+     * because the clock is hard-coded.
+     *
+     * @param zone  the zone ID to use, not null
+     * @return the current date using the system clock, not null
+     */
+    public static FrenchRepublicDate now(ZoneId zone) {
+        return now(Clock.system(zone));
+    }
+
+    /**
+     * Obtains the current {@code FrenchRepublicDate} from the specified clock.
+     * <p>
+     * This will query the specified clock to obtain the current date - today.
+     * Using this method allows the use of an alternate clock for testing.
+     * The alternate clock may be introduced using {@linkplain Clock dependency injection}.
+     *
+     * @param clock  the clock to use, not null
+     * @return the current date, not null
+     * @throws DateTimeException if the current date cannot be obtained
+     */
+    public static FrenchRepublicDate now(Clock clock) {
+        LocalDate now = LocalDate.now(clock);
+        return FrenchRepublicDate.ofEpochDay(now.toEpochDay());
+    }
+
+    /**
+     * Obtains a {@code FrenchRepublicDate} representing a date in the FrenchRepublic calendar
+     * system from the proleptic-year, month-of-year and day-of-month fields.
+     * <p>
+     * This returns a {@code FrenchRepublicDate} with the specified fields.
+     * The day must be valid for the year and month, otherwise an exception will be thrown.
+     *
+     * @param prolepticYear  the FrenchRepublic proleptic-year
+     * @param month  the FrenchRepublic month-of-year, from 1 to 13
+     * @param dayOfMonth  the FrenchRepublic day-of-month, from 1 to 30
+     * @return the date in FrenchRepublic calendar system, not null
+     * @throws DateTimeException if the value of any field is out of range,
+     *  or if the day-of-month is invalid for the month-year
+     */
+    public static FrenchRepublicDate of(int prolepticYear, int month, int dayOfMonth) {
+        return FrenchRepublicDate.create(prolepticYear, month, dayOfMonth);
+    }
+
+    /**
+     * Obtains a {@code FrenchRepublicDate} from a temporal object.
+     * <p>
+     * This obtains a date in the FrenchRepublic calendar system based on the specified temporal.
+     * A {@code TemporalAccessor} represents an arbitrary set of date and time information,
+     * which this factory converts to an instance of {@code FrenchRepublicDate}.
+     * <p>
+     * The conversion typically uses the {@link ChronoField#EPOCH_DAY EPOCH_DAY}
+     * field, which is standardized across calendar systems.
+     * <p>
+     * This method matches the signature of the functional interface {@link TemporalQuery}
+     * allowing it to be used as a query via method reference, {@code FrenchRepublicDate::from}.
+     *
+     * @param temporal  the temporal object to convert, not null
+     * @return the date in FrenchRepublic calendar system, not null
+     * @throws DateTimeException if unable to convert to a {@code FrenchRepublicDate}
+     */
+    public static FrenchRepublicDate from(TemporalAccessor temporal) {
+        if (temporal instanceof FrenchRepublicDate) {
+            return (FrenchRepublicDate) temporal;
+        }
+        return FrenchRepublicDate.ofEpochDay(temporal.getLong(EPOCH_DAY));
+    }
+
+    @Override
+    ValueRange rangeAlignedWeekOfMonth() {
+        return ValueRange.of(1, getMonth() == 13 ? 1 : 3);
+    }
+
+    @Override
+    public ValueRange range(TemporalField field) {
+        if (field.equals(WeekFields.ISO.dayOfWeek()))
+            return DOW_RANGE;
+
+        return super.range(field);
+    }    
+
+    @Override
+    public long getLong(TemporalField field) {
+        if (field.equals(WeekFields.ISO.dayOfWeek()))
+            return day;
+        return super.getLong(field);
+    }
+    
+    @Override
+    int getDayOfWeek() {
+        return (int) Math.floorMod(day, 10);
+    }
+
+    @Override
+    int lengthOfWeek() {
+        return 10;
+    }
+
+    
+    
+    //-----------------------------------------------------------------------
+    /**
+     * Obtains a {@code FrenchRepublicDate} representing a date in the FrenchRepublic calendar
+     * system from the proleptic-year and day-of-year fields.
+     * <p>
+     * This returns a {@code FrenchRepublicDate} with the specified fields.
+     * The day must be valid for the year, otherwise an exception will be thrown.
+     *
+     * @param prolepticYear  the FrenchRepublic proleptic-year
+     * @param dayOfYear  the FrenchRepublic day-of-year, from 1 to 366
+     * @return the date in FrenchRepublic calendar system, not null
+     * @throws DateTimeException if the value of any field is out of range,
+     *  or if the day-of-year is invalid for the year
+     */
+    static FrenchRepublicDate ofYearDay(int prolepticYear, int dayOfYear) {
+        FrenchRepublicChronology.YEAR_RANGE.checkValidValue(prolepticYear, YEAR);
+        DAY_OF_YEAR.range().checkValidValue(dayOfYear, DAY_OF_YEAR);
+        if (dayOfYear == 366 && !FrenchRepublicChronology.INSTANCE.isLeapYear(prolepticYear)) {
+            throw new DateTimeException("Invalid date 'Complementary day 6' as '" + prolepticYear + "' is not a leap year");
+        }
+        return new FrenchRepublicDate(prolepticYear, (dayOfYear - 1) / 30 + 1, (dayOfYear - 1) % 30 + 1);
+    }
+
+    /**
+     * Obtains a {@code FrenchRepublicDate} representing a date in the FrenchRepublic calendar
+     * system from the epoch-day.
+     *
+     * @param epochDay  the epoch day to convert based on 1970-01-01 (ISO)
+     * @return the date in FrenchRepublic calendar system, not null
+     * @throws DateTimeException if the epoch-day is out of range
+     */
+    static FrenchRepublicDate ofEpochDay(final long epochDay) {
+        EPOCH_DAY.range().checkValidValue(epochDay, EPOCH_DAY);  // validate outer bounds
+        // use of French Rev. -1 makes leap year at the end of cycle
+        long frenchRevEpochDayPlus365 = epochDay + EPOCH_DAY_DIFFERENCE + 365;
+        long cycle = Math.floorDiv(frenchRevEpochDayPlus365, DAYS_PER_CYCLE);
+        long daysInCycle = Math.floorMod(frenchRevEpochDayPlus365, DAYS_PER_CYCLE);
+        if (daysInCycle == DAYS_PER_CYCLE - 1) {
+            int year = (int) (cycle * 4 + 3);
+            return ofYearDay(year, 366);
+        }
+        int year = (int) (cycle * 4 + daysInCycle / 365);
+        int doy = (int) ((daysInCycle % 365) + 1);
+        return ofYearDay(year, doy);
+    }
+
+    private static FrenchRepublicDate resolvePreviousValid(int prolepticYear, int month, int day) {
+        if (month == 13 && day > 5) {
+            day = FrenchRepublicChronology.INSTANCE.isLeapYear(prolepticYear) ? 6 : 5;
+        }
+        return new FrenchRepublicDate(prolepticYear, month, day);
+    }
+
+    /**
+     * Creates a {@code FrenchRepublicDate} validating the input.
+     *
+     * @param prolepticYear  the FrenchRepublic proleptic-year
+     * @param month  the FrenchRepublic month-of-year, from 1 to 13
+     * @param dayOfMonth  the FrenchRepublic day-of-month, from 1 to 30
+     * @return the date in FrenchRepublic calendar system, not null
+     * @throws DateTimeException if the value of any field is out of range,
+     *  or if the day-of-month is invalid for the month-year
+     */
+    static FrenchRepublicDate create(int prolepticYear, int month, int dayOfMonth) {
+        FrenchRepublicChronology.YEAR_RANGE.checkValidValue(prolepticYear, YEAR);
+        FrenchRepublicChronology.MOY_RANGE.checkValidValue(month, MONTH_OF_YEAR);
+        FrenchRepublicChronology.DOM_RANGE.checkValidValue(dayOfMonth, DAY_OF_MONTH);
+        if (month == 13 && dayOfMonth > 5) {
+            if (FrenchRepublicChronology.INSTANCE.isLeapYear(prolepticYear)) {
+                if (dayOfMonth > 6) {
+                    throw new DateTimeException("Invalid date 'Complementary day " + dayOfMonth + "', valid range from 1 to 5, or 1 to 6 in a leap year");
+                }
+            } else {
+                if (dayOfMonth == 6) {
+                    throw new DateTimeException("Invalid date 'Complementary day 6' as '" + prolepticYear + "' is not a leap year");
+                } else {
+                    throw new DateTimeException("Invalid date 'Complementary day " + dayOfMonth + "', valid range from 1 to 5, or 1 to 6 in a leap year");
+                }
+            }
+        }
+        return new FrenchRepublicDate(prolepticYear, month, dayOfMonth);
+    }
+
+    //-----------------------------------------------------------------------
+    /**
+     * Creates an instance from validated data.
+     *
+     * @param prolepticYear  the FrenchRepublic proleptic-year
+     * @param month  the FrenchRepublic month, from 1 to 13
+     * @param dayOfMonth  the FrenchRepublic day-of-month, from 1 to 30
+     */
+    private FrenchRepublicDate(int prolepticYear, int month, int dayOfMonth) {
+        this.prolepticYear = prolepticYear;
+        this.month = (short) month;
+        this.day = (short) dayOfMonth;
+    }
+
+    /**
+     * Validates the object.
+     *
+     * @return the resolved date, not null
+     */
+    private Object readResolve() {
+        return FrenchRepublicDate.create(prolepticYear, month, day);
+    }
+
+    //-----------------------------------------------------------------------
+    @Override
+    int getEpochDayDifference() {
+        return EPOCH_DAY_DIFFERENCE;
+    }
+
+    @Override
+    int getProlepticYear() {
+        return prolepticYear;
+    }
+
+    @Override
+    int getMonth() {
+        return month;
+    }
+
+    @Override
+    int getDayOfMonth() {
+        return day;
+    }
+
+    @Override
+    FrenchRepublicDate resolvePrevious(int newYear, int newMonth, int dayOfMonth) {
+        return resolvePreviousValid(newYear, newMonth, dayOfMonth);
+    }
+
+    //-----------------------------------------------------------------------
+    /**
+     * Gets the chronology of this date, which is the FrenchRepublic calendar system.
+     * <p>
+     * The {@code Chronology} represents the calendar system in use.
+     * The era and other fields in {@link ChronoField} are defined by the chronology.
+     *
+     * @return the FrenchRepublic chronology, not null
+     */
+    @Override
+    public FrenchRepublicChronology getChronology() {
+        return FrenchRepublicChronology.INSTANCE;
+    }
+
+    /**
+     * Gets the era applicable at this date.
+     * <p>
+     * The FrenchRepublic calendar system has two eras, 'AM' and 'BEFORE_AM',
+     * defined by {@link FrenchRepublicEra}.
+     *
+     * @return the era applicable at this date, not null
+     */
+    @Override
+    public FrenchRepublicEra getEra() {
+        return (prolepticYear >= 1 ? FrenchRepublicEra.REPUBLICAN : FrenchRepublicEra.BEFORE_REPUBLICAN);
+    }
+
+    //-------------------------------------------------------------------------
+    @Override
+    public FrenchRepublicDate with(TemporalAdjuster adjuster) {
+        return (FrenchRepublicDate) adjuster.adjustInto(this);
+    }
+
+    @Override
+    public FrenchRepublicDate with(TemporalField field, long newValue) {
+        return (FrenchRepublicDate) super.with(field, newValue);
+    }
+
+    //-----------------------------------------------------------------------
+    @Override
+    public FrenchRepublicDate plus(TemporalAmount amount) {
+        return (FrenchRepublicDate) amount.addTo(this);
+    }
+
+    @Override
+    public FrenchRepublicDate plus(long amountToAdd, TemporalUnit unit) {
+        return (FrenchRepublicDate) super.plus(amountToAdd, unit);
+    }
+
+    @Override
+    public FrenchRepublicDate minus(TemporalAmount amount) {
+        return (FrenchRepublicDate) amount.subtractFrom(this);
+    }
+
+    @Override
+    public FrenchRepublicDate minus(long amountToSubtract, TemporalUnit unit) {
+        return (amountToSubtract == Long.MIN_VALUE ? plus(Long.MAX_VALUE, unit).plus(1, unit) : plus(-amountToSubtract, unit));
+    }
+
+    //-------------------------------------------------------------------------
+    @Override  // for covariant return type
+    @SuppressWarnings("unchecked")
+    public ChronoLocalDateTime<FrenchRepublicDate> atTime(LocalTime localTime) {
+        return (ChronoLocalDateTime<FrenchRepublicDate>) ChronoLocalDate.super.atTime(localTime);
+    }
+
+    @Override
+    public long until(Temporal endExclusive, TemporalUnit unit) {
+        return super.until(FrenchRepublicDate.from(endExclusive), unit);
+    }
+
+    @Override
+    public ChronoPeriod until(ChronoLocalDate endDateExclusive) {
+        return super.doUntil(FrenchRepublicDate.from(endDateExclusive));
+    }
+
+    @Override
+    public long toEpochDay() {
+        long year = (long) getProlepticYear();
+        long calendarEpochDay = (year * 365) + Math.floorDiv(year, 4) + (getDayOfYear() - 1);
+        return calendarEpochDay - 365 - getEpochDayDifference();
+    }    
+}

--- a/src/main/java/org/threeten/extra/chrono/FrenchRepublicDate.java
+++ b/src/main/java/org/threeten/extra/chrono/FrenchRepublicDate.java
@@ -209,6 +209,7 @@ public final class FrenchRepublicDate
 
     @Override
     public long getLong(TemporalField field) {
+        if (WeekFields.ISO.dayOfWeek().equals(field)) {
             return day;
         }
         return super.getLong(field);

--- a/src/main/java/org/threeten/extra/chrono/FrenchRepublicDate.java
+++ b/src/main/java/org/threeten/extra/chrono/FrenchRepublicDate.java
@@ -62,8 +62,9 @@ import static org.threeten.extra.chrono.FrenchRepublicChronology.DOW_RANGE;
  * A date in the FrenchRepublic calendar system.
  * <p>
  * This date operates using the {@linkplain FrenchRepublicChronology FrenchRepublic calendar}.
- * This calendar system is primarily used in Christian Egypt.
- * Dates are aligned such that {@code 0001-01-01 (FrenchRepublic)} is {@code 0284-08-29 (ISO)}.
+ * This calendar was used in France after the revolution, in the years 1793-1805 and shortly
+ * for 18 days in 1871 (see https://en.wikipedia.org/wiki/French_Republican_Calendar)
+ * Dates are aligned such that {@code 0001-01-01 (FrenchRepublic)} is {@code 1972-09-22 (ISO)}.
  *
  * <h3>Implementation Requirements</h3>
  * This class is immutable and thread-safe.
@@ -199,16 +200,17 @@ public final class FrenchRepublicDate
 
     @Override
     public ValueRange range(TemporalField field) {
-        if (field.equals(WeekFields.ISO.dayOfWeek()))
+        if (WeekFields.ISO.dayOfWeek().equals(field)) {
             return DOW_RANGE;
+        }
 
         return super.range(field);
     }    
 
     @Override
     public long getLong(TemporalField field) {
-        if (field.equals(WeekFields.ISO.dayOfWeek()))
             return day;
+        }
         return super.getLong(field);
     }
     

--- a/src/main/java/org/threeten/extra/chrono/FrenchRepublicDate.java
+++ b/src/main/java/org/threeten/extra/chrono/FrenchRepublicDate.java
@@ -199,22 +199,6 @@ public final class FrenchRepublicDate
         return ValueRange.of(1, getMonth() == 13 ? 1 : 3);
     }
 
-    @Override
-    public ValueRange range(TemporalField field) {
-        if (DAY_OF_WEEK.equals(field)) {
-            return DOW_RANGE;
-        }
-
-        return super.range(field);
-    }
-
-    @Override
-    public long getLong(TemporalField field) {
-        if (DAY_OF_WEEK.equals(field)) {
-            return day;
-        }
-        return super.getLong(field);
-    }
 
     @Override
     int getDayOfWeek() {

--- a/src/main/java/org/threeten/extra/chrono/FrenchRepublicDate.java
+++ b/src/main/java/org/threeten/extra/chrono/FrenchRepublicDate.java
@@ -300,7 +300,7 @@ public final class FrenchRepublicDate
      */
     static FrenchRepublicDate ofEpochDay(final long epochDay) {
         EPOCH_DAY.range().checkValidValue(epochDay, EPOCH_DAY);  // validate outer bounds
-        // use of French Rev. -1 makes leap year at the end of cycle
+        // use of French Republican year - 1 places leap year at the end of cycle
         long frenchRevEpochDayPlus365 = epochDay + EPOCH_DAY_DIFFERENCE + 365;
         long cycle = Math.floorDiv(frenchRevEpochDayPlus365, DAYS_PER_CYCLE);
         long daysInCycle = Math.floorMod(frenchRevEpochDayPlus365, DAYS_PER_CYCLE);
@@ -358,8 +358,8 @@ public final class FrenchRepublicDate
         this.prolepticYear = prolepticYear;
         this.month = month;
         this.day = dayOfMonth;
-        long calendarEpochDay = (prolepticYear * 365) + Math.floorDiv(prolepticYear, 4) + (getDayOfYear() - 1);
-        this.epochDay = calendarEpochDay - 365 - EPOCH_DAY_DIFFERENCE;
+        this.epochDay = ((prolepticYear - 1) * 365) + Math.floorDiv(prolepticYear, 4) +
+                (getDayOfYear() - 1) - EPOCH_DAY_DIFFERENCE;
     }
 
     /**

--- a/src/main/java/org/threeten/extra/chrono/FrenchRepublicDate.java
+++ b/src/main/java/org/threeten/extra/chrono/FrenchRepublicDate.java
@@ -32,7 +32,6 @@
 package org.threeten.extra.chrono;
 
 import static java.time.temporal.ChronoField.DAY_OF_MONTH;
-import static java.time.temporal.ChronoField.DAY_OF_WEEK;
 import static java.time.temporal.ChronoField.DAY_OF_YEAR;
 import static java.time.temporal.ChronoField.EPOCH_DAY;
 import static java.time.temporal.ChronoField.MONTH_OF_YEAR;
@@ -55,9 +54,9 @@ import java.time.temporal.TemporalAmount;
 import java.time.temporal.TemporalField;
 import java.time.temporal.TemporalQuery;
 import java.time.temporal.TemporalUnit;
+import java.time.temporal.UnsupportedTemporalTypeException;
 import java.time.temporal.ValueRange;
-import java.time.temporal.WeekFields;
-import static org.threeten.extra.chrono.FrenchRepublicChronology.DOW_RANGE;
+
 
 /**
  * A date in the FrenchRepublic calendar system.
@@ -74,7 +73,7 @@ import static org.threeten.extra.chrono.FrenchRepublicChronology.DOW_RANGE;
  * identity hash code or use the distinction between equals() and ==.
  */
 public final class FrenchRepublicDate
-        extends AbstractNileDate
+        extends AbstractDate
         implements ChronoLocalDate, Serializable {
 
     /**
@@ -98,11 +97,15 @@ public final class FrenchRepublicDate
     /**
      * The month.
      */
-    private final short month;
+    private final int month;
     /**
      * The day.
      */
-    private final short day;
+    private final int day;
+    /**
+     * Epoch day
+     */
+    private final long epochDay;
 
     //-----------------------------------------------------------------------
     /**
@@ -196,13 +199,16 @@ public final class FrenchRepublicDate
 
     @Override
     ValueRange rangeAlignedWeekOfMonth() {
-        return ValueRange.of(1, getMonth() == 13 ? 1 : 3);
+        return ValueRange.of(getMonth() != 13 ? 1 : 0, getMonth() != 13 ? 3 : 0);
     }
 
 
     @Override
     int getDayOfWeek() {
-        return (int) Math.floorMod(day, 10);
+        if (month == 13) {
+            return 0;
+        }
+        return Math.floorMod(day, 10);
     }
 
     @Override
@@ -210,8 +216,57 @@ public final class FrenchRepublicDate
         return 10;
     }
 
+    @Override
+    public int lengthOfMonth() {
+        if (getMonth() != 13) {
+            return 30;
+        }
+        return 0;
+    }
 
+    @Override
+    int lengthOfYearInMonths() {
+        return 12;
+    }
 
+    @Override
+    int getDayOfYear() {
+        return (getMonth() - 1) * 30 + getDayOfMonth();
+    }
+
+    @Override
+    public ValueRange range(TemporalField field) {
+        if (field instanceof ChronoField) {
+            if (isSupported(field)) {
+                ChronoField f = (ChronoField) field;
+                switch (f) {
+                    case ALIGNED_DAY_OF_WEEK_IN_MONTH:
+                    case ALIGNED_DAY_OF_WEEK_IN_YEAR:
+                    case DAY_OF_WEEK:
+                        return month != 13 ? FrenchRepublicChronology.DOW_RANGE : FrenchRepublicChronology.EMPTY;
+                    case ALIGNED_WEEK_OF_MONTH:
+                        return month != 13 ? ValueRange.of(1, 3) : FrenchRepublicChronology.EMPTY;
+                    case ALIGNED_WEEK_OF_YEAR:
+                        return month != 13 ? ValueRange.of(1, 36) : FrenchRepublicChronology.EMPTY;
+                    case DAY_OF_MONTH:
+                        return month != 13 ? ValueRange.of(1, lengthOfMonth()) : FrenchRepublicChronology.EMPTY;
+                    case DAY_OF_YEAR:
+                        return isLeapYear() ? ValueRange.of(1, 366) : ValueRange.of(1, 365);
+                    //case EPOCH_DAY:
+                    //    return ValueRange.of(-999_999, 999_999);
+                    //case ERA:
+                    //    return ERA_RANGE;
+                    case MONTH_OF_YEAR:
+                        return ValueRange.of(1, 12);
+                    default:
+                        break;
+                }
+            } else {
+                throw new UnsupportedTemporalTypeException("Unsupported field: " + field);
+            }
+        }
+        return super.range(field);
+    }
     //-----------------------------------------------------------------------
     /**
      * Obtains a {@code FrenchRepublicDate} representing a date in the FrenchRepublic calendar
@@ -301,8 +356,10 @@ public final class FrenchRepublicDate
      */
     private FrenchRepublicDate(int prolepticYear, int month, int dayOfMonth) {
         this.prolepticYear = prolepticYear;
-        this.month = (short) month;
-        this.day = (short) dayOfMonth;
+        this.month = month;
+        this.day = dayOfMonth;
+        long calendarEpochDay = (prolepticYear * 365) + Math.floorDiv(prolepticYear, 4) + (getDayOfYear() - 1);
+        this.epochDay = calendarEpochDay - 365 - EPOCH_DAY_DIFFERENCE;
     }
 
     /**
@@ -315,10 +372,6 @@ public final class FrenchRepublicDate
     }
 
     //-----------------------------------------------------------------------
-    @Override
-    int getEpochDayDifference() {
-        return EPOCH_DAY_DIFFERENCE;
-    }
 
     @Override
     int getProlepticYear() {
@@ -333,6 +386,10 @@ public final class FrenchRepublicDate
     @Override
     int getDayOfMonth() {
         return day;
+    }
+
+    private long getProlepticWeek() {
+        return getProlepticMonth() * 3 + ((getDayOfMonth() - 1) / 10) - 1;
     }
 
     @Override
@@ -357,7 +414,7 @@ public final class FrenchRepublicDate
     /**
      * Gets the era applicable at this date.
      * <p>
-     * The FrenchRepublic calendar system has two eras, 'AM' and 'BEFORE_AM',
+     * The FrenchRepublic calendar system has two eras, 'REPUBLICAN' and 'BEFORE_REPUBLICAN',
      * defined by {@link FrenchRepublicEra}.
      *
      * @return the era applicable at this date, not null
@@ -389,6 +446,44 @@ public final class FrenchRepublicDate
         return (FrenchRepublicDate) super.plus(amountToAdd, unit);
     }
 
+    /*
+    */
+    @Override
+    FrenchRepublicDate plusMonths(long months) {
+        if (months % 12 == 0) {
+            return (FrenchRepublicDate) plusYears(months / 12);
+        }
+        if (month == 13 || 0 == months) {
+            return this;
+        }
+        return (FrenchRepublicDate) super.plusMonths(months);
+    }
+
+    @Override
+    FrenchRepublicDate plusWeeks(long weeks) {
+        if (weeks % 3 == 0) {
+            return plusMonths(weeks / 3);
+        }
+        if (month == 13 || 0 == weeks) {
+            return this;
+        }
+        long curEm = getProlepticWeek();
+        long calcEm = Math.addExact(curEm, weeks) + 1;
+        int newYear = Math.toIntExact(Math.floorDiv(calcEm, lengthOfYearInMonths() * 3));
+        int yearWeeks = (int) Math.floorMod(calcEm, lengthOfYearInMonths() * 3);
+        int weekDays = ((getDayOfMonth() - 1) % lengthOfWeek()) + 1;
+        int newMonth = yearWeeks / 3 + 1;
+        return resolvePrevious(newYear, newMonth, (yearWeeks % 3) * lengthOfWeek() + weekDays);
+    }
+
+    @Override
+    FrenchRepublicDate plusDays(long days) {
+        if (days % 10 == 0) {
+            return plusWeeks(days / 10);
+        }
+        return (FrenchRepublicDate) super.plusDays(days);
+    }
+
     @Override
     public FrenchRepublicDate minus(TemporalAmount amount) {
         return (FrenchRepublicDate) amount.subtractFrom(this);
@@ -418,8 +513,6 @@ public final class FrenchRepublicDate
 
     @Override
     public long toEpochDay() {
-        long year = (long) getProlepticYear();
-        long calendarEpochDay = (year * 365) + Math.floorDiv(year, 4) + (getDayOfYear() - 1);
-        return calendarEpochDay - 365 - getEpochDayDifference();
+        return this.epochDay;
     }
 }

--- a/src/main/java/org/threeten/extra/chrono/FrenchRepublicEra.java
+++ b/src/main/java/org/threeten/extra/chrono/FrenchRepublicEra.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) 2007-present, Stephen Colebourne & Michael Nascimento Santos
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *  * Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ *  * Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ *  * Neither the name of JSR-310 nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.threeten.extra.chrono;
+
+import java.time.DateTimeException;
+import java.time.chrono.Era;
+
+/**
+ * An era in the FrenchRepublic calendar system.
+ * <p>
+ * The French Republican calendar system has only one official era for years from 1 onwards.
+ * All previous years, zero or earlier, are part of the 'Before Republican' era.
+ * <p>
+ * The start of the French Republican epoch {@code 0001-01-01 (French Republican)} is {@code 1792-09-22 (ISO)}.
+ * <p>
+ * <b>Do not use {@code ordinal()} to obtain the numeric representation of {@code FrenchRepublicEra}.
+ * Use {@code getValue()} instead.</b>
+ *
+ * <h3>Implementation Requirements:</h3>
+ * This is an immutable and thread-safe enum.
+ */
+public enum FrenchRepublicEra implements Era {
+
+    /**
+     * The singleton instance for the era before the republican era
+     * which has the numeric value 0.
+     */
+    BEFORE_REPUBLICAN,
+    /**
+     * The singleton instance for the republican era, starting at the gregorian
+     * date 22 septembre 1792
+     * which has the numeric value 1.
+     */
+    REPUBLICAN;
+
+    //-----------------------------------------------------------------------
+    /**
+     * Obtains an instance of {@code FrenchRepublicEra} from an {@code int} value.
+     * <p>
+     * {@code FrenchRepublicEra} is an enum representing the FrenchRepublic eras of BEFORE_REPUBLICAN/REPUBLICAN.
+     * This factory allows the enum to be obtained from the {@code int} value.
+     *
+     * @param era  the BEFORE_REPUBLICAN/REPUBLICAN value to represent, from 0 (BEFORE_REPUBLICAN) to 1 (REPUBLICAN)
+     * @return the era singleton, not null
+     * @throws DateTimeException if the value is invalid
+     */
+    public static FrenchRepublicEra of(int era) {
+        switch (era) {
+            case 0:
+                return BEFORE_REPUBLICAN;
+            case 1:
+                return REPUBLICAN;
+            default:
+                throw new DateTimeException("Invalid era: " + era);
+        }
+    }
+
+    //-----------------------------------------------------------------------
+    /**
+     * Gets the numeric era {@code int} value.
+     * <p>
+     * The era BEFORE_REPUBLICAN has the value 0, while the era REPUBLICAN has the value 1.
+     *
+     * @return the era value, from 0 (BEFORE_REPUBLICAN) to 1 (REPUBLICAN)
+     */
+    @Override
+    public int getValue() {
+        return ordinal();
+    }
+
+}

--- a/src/main/resources/META-INF/services/java.time.chrono.Chronology
+++ b/src/main/resources/META-INF/services/java.time.chrono.Chronology
@@ -4,6 +4,7 @@ org.threeten.extra.chrono.DiscordianChronology
 org.threeten.extra.chrono.EthiopicChronology
 org.threeten.extra.chrono.InternationalFixedChronology
 org.threeten.extra.chrono.JulianChronology
+org.threeten.extra.chrono.FrenchRepublicChronology
 org.threeten.extra.chrono.PaxChronology
 org.threeten.extra.chrono.Symmetry010Chronology
 org.threeten.extra.chrono.Symmetry454Chronology

--- a/src/test/java/org/threeten/extra/chrono/TestFrenchRepublicChronology.java
+++ b/src/test/java/org/threeten/extra/chrono/TestFrenchRepublicChronology.java
@@ -113,7 +113,7 @@ public class TestFrenchRepublicChronology {
             {FrenchRepublicDate.of(1, 1, 2), LocalDate.of(1792, 9, 23)},
             {FrenchRepublicDate.of(1, 1, 3), LocalDate.of(1792, 9, 24)},
             {FrenchRepublicDate.of(1, 1, 30), LocalDate.of(1792, 10, 21)},
-          
+
             {FrenchRepublicDate.of(1, 4, 11), LocalDate.of(1792, 12, 31)},
             {FrenchRepublicDate.of(1, 4, 12), LocalDate.of(1793, 1, 1)},
             {FrenchRepublicDate.of(1, 6, 10), LocalDate.of(1793, 2, 28)},
@@ -125,7 +125,7 @@ public class TestFrenchRepublicChronology {
             {FrenchRepublicDate.of(1, 13, 3), LocalDate.of(1793, 9, 19)},
             {FrenchRepublicDate.of(1, 13, 4), LocalDate.of(1793, 9, 20)},
             {FrenchRepublicDate.of(1, 13, 5), LocalDate.of(1793, 9, 21)},
-            
+
             {FrenchRepublicDate.of(2, 1, 1), LocalDate.of(1793, 9, 22)},
             {FrenchRepublicDate.of(2, 1, 2), LocalDate.of(1793, 9, 23)},
             {FrenchRepublicDate.of(2, 1, 3), LocalDate.of(1793, 9, 24)},
@@ -140,7 +140,7 @@ public class TestFrenchRepublicChronology {
             {FrenchRepublicDate.of(2, 13, 3), LocalDate.of(1794, 9, 19)},
             {FrenchRepublicDate.of(2, 13, 4), LocalDate.of(1794, 9, 20)},
             {FrenchRepublicDate.of(2, 13, 5), LocalDate.of(1794, 9, 21)},
-            
+
             {FrenchRepublicDate.of(3, 1, 1), LocalDate.of(1794, 9, 22)},
             {FrenchRepublicDate.of(3, 1, 2), LocalDate.of(1794, 9, 23)},
             {FrenchRepublicDate.of(3, 1, 3), LocalDate.of(1794, 9, 24)},
@@ -154,7 +154,7 @@ public class TestFrenchRepublicChronology {
             {FrenchRepublicDate.of(3, 13, 2), LocalDate.of(1795, 9, 18)},
             {FrenchRepublicDate.of(3, 13, 3), LocalDate.of(1795, 9, 19)},
             {FrenchRepublicDate.of(3, 13, 4), LocalDate.of(1795, 9, 20)},
-            {FrenchRepublicDate.of(3, 13, 5), LocalDate.of(1795, 9, 21)},            
+            {FrenchRepublicDate.of(3, 13, 5), LocalDate.of(1795, 9, 21)},
             {FrenchRepublicDate.of(3, 13, 6), LocalDate.of(1795, 9, 22)},
 
             {FrenchRepublicDate.of(4, 1, 1), LocalDate.of(1795, 9, 23)},
@@ -173,23 +173,23 @@ public class TestFrenchRepublicChronology {
             {FrenchRepublicDate.of(4, 13, 4), LocalDate.of(1796, 9, 20)},
             {FrenchRepublicDate.of(4, 13, 5), LocalDate.of(1796, 9, 21)},
 
-            {FrenchRepublicDate.of(14, 4, 10), LocalDate.of(1805, 12, 31)},       
+            {FrenchRepublicDate.of(14, 4, 10), LocalDate.of(1805, 12, 31)},
             {FrenchRepublicDate.of(14, 4, 11), LocalDate.of(1806, 1, 1)},
-            
+
             {FrenchRepublicDate.of(15, 1, 1), LocalDate.of(1806, 9, 23)},
             {FrenchRepublicDate.of(16, 1, 1), LocalDate.of(1807, 9, 24)},
             {FrenchRepublicDate.of(17, 1, 1), LocalDate.of(1808, 9, 23)},
             {FrenchRepublicDate.of(18, 1, 1), LocalDate.of(1809, 9, 23)},
             {FrenchRepublicDate.of(19, 1, 1), LocalDate.of(1810, 9, 23)},
-            {FrenchRepublicDate.of(20, 1, 1), LocalDate.of(1811, 9, 24)},            
-            
+            {FrenchRepublicDate.of(20, 1, 1), LocalDate.of(1811, 9, 24)},
+
             {FrenchRepublicDate.of(79, 8, 16), LocalDate.of(1871, 5, 6)},
             {FrenchRepublicDate.of(79, 9, 3), LocalDate.of(1871, 5, 23)},
 
-            /*{FrenchRepublicDate.of(224, 1, 1), LocalDate.of(2015, 9, 23)},
-            {FrenchRepublicDate.of(225, 1, 1), LocalDate.of(2016, 9, 22)},
-            {FrenchRepublicDate.of(226, 1, 1), LocalDate.of(2017, 9, 22)},
-            {FrenchRepublicDate.of(227, 1, 1), LocalDate.of(2018, 9, 22)},*/
+            {FrenchRepublicDate.of(224, 1, 1), LocalDate.of(2015, 9, 25)},
+            {FrenchRepublicDate.of(225, 1, 1), LocalDate.of(2016, 9, 24)},
+            {FrenchRepublicDate.of(226, 1, 1), LocalDate.of(2017, 9, 24)},
+            {FrenchRepublicDate.of(227, 1, 1), LocalDate.of(2018, 9, 24)},
         };
     }
 
@@ -203,8 +203,8 @@ public class TestFrenchRepublicChronology {
         assertEquals(FrenchRepublicDate.from(iso), french);
     }
 
-    
-    
+
+
     @Test(dataProvider = "samples")
     public void test_FrenchRepublicDate_chronology_dateEpochDay(FrenchRepublicDate frenchRepublic, LocalDate iso) {
         assertEquals(FrenchRepublicChronology.INSTANCE.dateEpochDay(iso.toEpochDay()), frenchRepublic);
@@ -287,7 +287,7 @@ public class TestFrenchRepublicChronology {
             {1, 13, 8},
             {1, 13, 9},
             {1, 13, 10},
-          
+
             {3, 13, -1},
             {3, 13, 0},
             {3, 13, 7},
@@ -299,7 +299,7 @@ public class TestFrenchRepublicChronology {
             {1, 12, 0},
             {1, 12, 31},
             {1, 12, 32},
-          
+
             {1, 3, 31},
             {1, 4, 31},
             {1, 5, 31},
@@ -368,9 +368,9 @@ public class TestFrenchRepublicChronology {
             {1, 9, 30},
             {1, 10, 30},
             {1, 11, 30},
-            {1, 12, 30},            
+            {1, 12, 30},
             {1, 13, 5},
-          
+
             {1, 13, 5},
             {2, 13, 5},
             {3, 13, 6},
@@ -494,13 +494,10 @@ public class TestFrenchRepublicChronology {
             {1, 1, 23, ALIGNED_WEEK_OF_MONTH, 1, 3},
             {1, 12, 23, ALIGNED_WEEK_OF_MONTH, 1, 3},
             {1, 13, 2, ALIGNED_WEEK_OF_MONTH, 1, 1},
-            
+
             {3, 13, 2, DAY_OF_MONTH, 1, 6},
             {3, 13, 2, DAY_OF_YEAR, 1, 366},
             {3, 13, 2, ALIGNED_WEEK_OF_MONTH, 1, 1},
-            
-            {3, 2, 23, WeekFields.ISO.dayOfWeek(), 1, 10},
-
         };
     }
 
@@ -531,11 +528,9 @@ public class TestFrenchRepublicChronology {
             {1, 6, 8, PROLEPTIC_MONTH, 13 + 6 - 1},
             {1, 6, 8, YEAR, 1},
             {1, 6, 8, ERA, 1},
-            
+
             {1, 6, 8, ERA, 1},
             {0, 6, 8, ERA, 0},
-            
-            {1, 6, 8, WeekFields.ISO.dayOfWeek(), 8},
         };
     }
 
@@ -571,7 +566,7 @@ public class TestFrenchRepublicChronology {
             {1, 5, 26, ALIGNED_WEEK_OF_YEAR, 21, 1, 7, 26},
             {1, 5, 26, MONTH_OF_YEAR, 7, 1, 7, 26},
             {1, 5, 26, MONTH_OF_YEAR, 5, 1, 5, 26},
-            
+
             {1, 5, 26, PROLEPTIC_MONTH, 3 * 13 + 3 - 1, 3, 3, 26},
             {1, 5, 26, PROLEPTIC_MONTH, 4 * 13 + 5 - 1, 4, 5, 26},
             {1, 5, 26, YEAR, 2, 2, 5, 26},
@@ -586,7 +581,6 @@ public class TestFrenchRepublicChronology {
             {1, 3, 30, MONTH_OF_YEAR, 6, 1, 6, 30},
             {3, 13, 6, YEAR, 4, 4, 13, 5},
             {-3, 6, 8, YEAR_OF_ERA, 2, -1, 6, 8},
-            //{1, 5, 26, WeekFields.ISO.dayOfWeek(), 3, 1, 5, 23},
         };
     }
 

--- a/src/test/java/org/threeten/extra/chrono/TestFrenchRepublicChronology.java
+++ b/src/test/java/org/threeten/extra/chrono/TestFrenchRepublicChronology.java
@@ -1,0 +1,820 @@
+/*
+ * Copyright (c) 2007-present, Stephen Colebourne & Michael Nascimento Santos
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *  * Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ *  * Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ *  * Neither the name of JSR-310 nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.threeten.extra.chrono;
+
+import static java.time.temporal.ChronoField.ALIGNED_DAY_OF_WEEK_IN_MONTH;
+import static java.time.temporal.ChronoField.ALIGNED_DAY_OF_WEEK_IN_YEAR;
+import static java.time.temporal.ChronoField.ALIGNED_WEEK_OF_MONTH;
+import static java.time.temporal.ChronoField.ALIGNED_WEEK_OF_YEAR;
+import static java.time.temporal.ChronoField.DAY_OF_MONTH;
+import static java.time.temporal.ChronoField.DAY_OF_WEEK;
+import static java.time.temporal.ChronoField.DAY_OF_YEAR;
+import static java.time.temporal.ChronoField.ERA;
+import static java.time.temporal.ChronoField.MINUTE_OF_DAY;
+import static java.time.temporal.ChronoField.MONTH_OF_YEAR;
+import static java.time.temporal.ChronoField.PROLEPTIC_MONTH;
+import static java.time.temporal.ChronoField.YEAR;
+import static java.time.temporal.ChronoField.YEAR_OF_ERA;
+import static java.time.temporal.ChronoUnit.CENTURIES;
+import static java.time.temporal.ChronoUnit.DAYS;
+import static java.time.temporal.ChronoUnit.DECADES;
+import static java.time.temporal.ChronoUnit.ERAS;
+import static java.time.temporal.ChronoUnit.MILLENNIA;
+import static java.time.temporal.ChronoUnit.MINUTES;
+import static java.time.temporal.ChronoUnit.MONTHS;
+import static java.time.temporal.ChronoUnit.WEEKS;
+import static java.time.temporal.ChronoUnit.YEARS;
+import static org.testng.Assert.assertEquals;
+
+import java.time.DateTimeException;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.Month;
+import java.time.Period;
+import java.time.chrono.Chronology;
+import java.time.chrono.Era;
+import java.time.chrono.IsoEra;
+import java.time.temporal.IsoFields;
+import java.time.temporal.TemporalAdjusters;
+import java.time.temporal.TemporalField;
+import java.time.temporal.TemporalUnit;
+import java.time.temporal.UnsupportedTemporalTypeException;
+import java.time.temporal.ValueRange;
+import java.time.temporal.WeekFields;
+import java.util.List;
+
+import org.testng.Assert;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+/**
+ * Test.
+ */
+@Test
+public class TestFrenchRepublicChronology {
+
+    //-----------------------------------------------------------------------
+    // Chronology.of(String)
+    //-----------------------------------------------------------------------
+    @Test
+    public void test_chronology_of_name() {
+        Chronology chrono = Chronology.of("French Republican");
+        Assert.assertNotNull(chrono);
+        Assert.assertEquals(chrono, FrenchRepublicChronology.INSTANCE);
+        Assert.assertEquals(chrono.getId(), "French Republican");
+        Assert.assertEquals(chrono.getCalendarType(), "frenchrepublican");
+    }
+
+    @Test
+    public void test_chronology_of_name_id() {
+        Chronology chrono = Chronology.of("frenchrepublican");
+        Assert.assertNotNull(chrono);
+        Assert.assertEquals(chrono, FrenchRepublicChronology.INSTANCE);
+        Assert.assertEquals(chrono.getId(), "French Republican");
+        Assert.assertEquals(chrono.getCalendarType(), "frenchrepublican");
+    }
+
+    //-----------------------------------------------------------------------
+    // creation, toLocalDate()
+    //-----------------------------------------------------------------------
+    @DataProvider(name = "samples")
+    Object[][] data_samples() {
+        return new Object[][] {
+            {FrenchRepublicDate.of(1, 1, 1), LocalDate.of(1792, 9, 22)},
+            {FrenchRepublicDate.of(1, 1, 2), LocalDate.of(1792, 9, 23)},
+            {FrenchRepublicDate.of(1, 1, 3), LocalDate.of(1792, 9, 24)},
+            {FrenchRepublicDate.of(1, 1, 30), LocalDate.of(1792, 10, 21)},
+          
+            {FrenchRepublicDate.of(1, 4, 11), LocalDate.of(1792, 12, 31)},
+            {FrenchRepublicDate.of(1, 4, 12), LocalDate.of(1793, 1, 1)},
+            {FrenchRepublicDate.of(1, 6, 10), LocalDate.of(1793, 2, 28)},
+            {FrenchRepublicDate.of(1, 6, 11), LocalDate.of(1793, 3, 1)},
+
+            {FrenchRepublicDate.of(1, 12, 30), LocalDate.of(1793, 9, 16)},
+            {FrenchRepublicDate.of(1, 13, 1), LocalDate.of(1793, 9, 17)},
+            {FrenchRepublicDate.of(1, 13, 2), LocalDate.of(1793, 9, 18)},
+            {FrenchRepublicDate.of(1, 13, 3), LocalDate.of(1793, 9, 19)},
+            {FrenchRepublicDate.of(1, 13, 4), LocalDate.of(1793, 9, 20)},
+            {FrenchRepublicDate.of(1, 13, 5), LocalDate.of(1793, 9, 21)},
+            
+            {FrenchRepublicDate.of(2, 1, 1), LocalDate.of(1793, 9, 22)},
+            {FrenchRepublicDate.of(2, 1, 2), LocalDate.of(1793, 9, 23)},
+            {FrenchRepublicDate.of(2, 1, 3), LocalDate.of(1793, 9, 24)},
+            {FrenchRepublicDate.of(2, 1, 30), LocalDate.of(1793, 10, 21)},
+            {FrenchRepublicDate.of(2, 4, 11), LocalDate.of(1793, 12, 31)},
+            {FrenchRepublicDate.of(2, 4, 12), LocalDate.of(1794, 1, 1)},
+            {FrenchRepublicDate.of(2, 6, 10), LocalDate.of(1794, 2, 28)},
+            {FrenchRepublicDate.of(2, 6, 11), LocalDate.of(1794, 3, 1)},
+            {FrenchRepublicDate.of(2, 12, 30), LocalDate.of(1794, 9, 16)},
+            {FrenchRepublicDate.of(2, 13, 1), LocalDate.of(1794, 9, 17)},
+            {FrenchRepublicDate.of(2, 13, 2), LocalDate.of(1794, 9, 18)},
+            {FrenchRepublicDate.of(2, 13, 3), LocalDate.of(1794, 9, 19)},
+            {FrenchRepublicDate.of(2, 13, 4), LocalDate.of(1794, 9, 20)},
+            {FrenchRepublicDate.of(2, 13, 5), LocalDate.of(1794, 9, 21)},
+            
+            {FrenchRepublicDate.of(3, 1, 1), LocalDate.of(1794, 9, 22)},
+            {FrenchRepublicDate.of(3, 1, 2), LocalDate.of(1794, 9, 23)},
+            {FrenchRepublicDate.of(3, 1, 3), LocalDate.of(1794, 9, 24)},
+            {FrenchRepublicDate.of(3, 1, 30), LocalDate.of(1794, 10, 21)},
+            {FrenchRepublicDate.of(3, 4, 11), LocalDate.of(1794, 12, 31)},
+            {FrenchRepublicDate.of(3, 4, 12), LocalDate.of(1795, 1, 1)},
+            {FrenchRepublicDate.of(3, 6, 10), LocalDate.of(1795, 2, 28)},
+            {FrenchRepublicDate.of(3, 6, 11), LocalDate.of(1795, 3, 1)},
+            {FrenchRepublicDate.of(3, 12, 30), LocalDate.of(1795, 9, 16)},
+            {FrenchRepublicDate.of(3, 13, 1), LocalDate.of(1795, 9, 17)},
+            {FrenchRepublicDate.of(3, 13, 2), LocalDate.of(1795, 9, 18)},
+            {FrenchRepublicDate.of(3, 13, 3), LocalDate.of(1795, 9, 19)},
+            {FrenchRepublicDate.of(3, 13, 4), LocalDate.of(1795, 9, 20)},
+            {FrenchRepublicDate.of(3, 13, 5), LocalDate.of(1795, 9, 21)},            
+            {FrenchRepublicDate.of(3, 13, 6), LocalDate.of(1795, 9, 22)},
+
+            {FrenchRepublicDate.of(4, 1, 1), LocalDate.of(1795, 9, 23)},
+            {FrenchRepublicDate.of(4, 1, 2), LocalDate.of(1795, 9, 24)},
+            {FrenchRepublicDate.of(4, 1, 3), LocalDate.of(1795, 9, 25)},
+            {FrenchRepublicDate.of(4, 1, 30), LocalDate.of(1795, 10, 22)},
+            {FrenchRepublicDate.of(4, 4, 10), LocalDate.of(1795, 12, 31)},
+            {FrenchRepublicDate.of(4, 4, 11), LocalDate.of(1796, 1, 1)},
+            {FrenchRepublicDate.of(4, 6, 9), LocalDate.of(1796, 2, 28)},
+            {FrenchRepublicDate.of(4, 6, 10), LocalDate.of(1796, 2, 29)},
+            {FrenchRepublicDate.of(4, 6, 11), LocalDate.of(1796, 3, 1)},
+            {FrenchRepublicDate.of(4, 12, 30), LocalDate.of(1796, 9, 16)},
+            {FrenchRepublicDate.of(4, 13, 1), LocalDate.of(1796, 9, 17)},
+            {FrenchRepublicDate.of(4, 13, 2), LocalDate.of(1796, 9, 18)},
+            {FrenchRepublicDate.of(4, 13, 3), LocalDate.of(1796, 9, 19)},
+            {FrenchRepublicDate.of(4, 13, 4), LocalDate.of(1796, 9, 20)},
+            {FrenchRepublicDate.of(4, 13, 5), LocalDate.of(1796, 9, 21)},
+
+            {FrenchRepublicDate.of(14, 4, 10), LocalDate.of(1805, 12, 31)},       
+            {FrenchRepublicDate.of(14, 4, 11), LocalDate.of(1806, 1, 1)},
+            
+            {FrenchRepublicDate.of(15, 1, 1), LocalDate.of(1806, 9, 23)},
+            {FrenchRepublicDate.of(16, 1, 1), LocalDate.of(1807, 9, 24)},
+            {FrenchRepublicDate.of(17, 1, 1), LocalDate.of(1808, 9, 23)},
+            {FrenchRepublicDate.of(18, 1, 1), LocalDate.of(1809, 9, 23)},
+            {FrenchRepublicDate.of(19, 1, 1), LocalDate.of(1810, 9, 23)},
+            {FrenchRepublicDate.of(20, 1, 1), LocalDate.of(1811, 9, 24)},            
+            
+            {FrenchRepublicDate.of(79, 8, 16), LocalDate.of(1871, 5, 6)},
+            {FrenchRepublicDate.of(79, 9, 3), LocalDate.of(1871, 5, 23)},
+
+            /*{FrenchRepublicDate.of(224, 1, 1), LocalDate.of(2015, 9, 23)},
+            {FrenchRepublicDate.of(225, 1, 1), LocalDate.of(2016, 9, 22)},
+            {FrenchRepublicDate.of(226, 1, 1), LocalDate.of(2017, 9, 22)},
+            {FrenchRepublicDate.of(227, 1, 1), LocalDate.of(2018, 9, 22)},*/
+        };
+    }
+
+    @Test(dataProvider = "samples")
+    public void test_LocalDate_from_FrenchRepublicDate(FrenchRepublicDate french, LocalDate iso) {
+        assertEquals(LocalDate.from(french), iso);
+    }
+
+    @Test(dataProvider = "samples")
+    public void test_FrenchRepublicDate_from_LocalDate(FrenchRepublicDate french, LocalDate iso) {
+        assertEquals(FrenchRepublicDate.from(iso), french);
+    }
+
+    
+    
+    @Test(dataProvider = "samples")
+    public void test_FrenchRepublicDate_chronology_dateEpochDay(FrenchRepublicDate frenchRepublic, LocalDate iso) {
+        assertEquals(FrenchRepublicChronology.INSTANCE.dateEpochDay(iso.toEpochDay()), frenchRepublic);
+    }
+
+    @Test(dataProvider = "samples")
+    public void test_FrenchRepublicDate_toEpochDay(FrenchRepublicDate frenchRepublic, LocalDate iso) {
+        assertEquals(frenchRepublic.toEpochDay(), iso.toEpochDay());
+    }
+
+    @Test(dataProvider = "samples")
+    public void test_FrenchRepublicDate_until_FrenchRepublicDate(FrenchRepublicDate frenchRepublic, LocalDate iso) {
+        assertEquals(frenchRepublic.until(frenchRepublic), FrenchRepublicChronology.INSTANCE.period(0, 0, 0));
+    }
+
+    @Test(dataProvider = "samples")
+    public void test_FrenchRepublicDate_until_LocalDate(FrenchRepublicDate frenchRepublic, LocalDate iso) {
+        assertEquals(frenchRepublic.until(iso), FrenchRepublicChronology.INSTANCE.period(0, 0, 0));
+    }
+
+    @Test(dataProvider = "samples")
+    public void test_LocalDate_until_FrenchRepublicDate(FrenchRepublicDate frenchRepublic, LocalDate iso) {
+        assertEquals(iso.until(frenchRepublic), Period.ZERO);
+    }
+
+    @Test(dataProvider = "samples")
+    public void test_Chronology_date_Temporal(FrenchRepublicDate frenchRepublic, LocalDate iso) {
+        assertEquals(FrenchRepublicChronology.INSTANCE.date(iso), frenchRepublic);
+    }
+
+    @Test(dataProvider = "samples")
+    public void test_plusDays(FrenchRepublicDate frenchRepublic, LocalDate iso) {
+        assertEquals(LocalDate.from(frenchRepublic.plus(0, DAYS)), iso);
+        assertEquals(LocalDate.from(frenchRepublic.plus(1, DAYS)), iso.plusDays(1));
+        assertEquals(LocalDate.from(frenchRepublic.plus(35, DAYS)), iso.plusDays(35));
+        assertEquals(LocalDate.from(frenchRepublic.plus(-1, DAYS)), iso.plusDays(-1));
+        assertEquals(LocalDate.from(frenchRepublic.plus(-60, DAYS)), iso.plusDays(-60));
+    }
+
+    @Test(dataProvider = "samples")
+    public void test_minusDays(FrenchRepublicDate frenchRepublic, LocalDate iso) {
+        assertEquals(LocalDate.from(frenchRepublic.minus(0, DAYS)), iso);
+        assertEquals(LocalDate.from(frenchRepublic.minus(1, DAYS)), iso.minusDays(1));
+        assertEquals(LocalDate.from(frenchRepublic.minus(35, DAYS)), iso.minusDays(35));
+        assertEquals(LocalDate.from(frenchRepublic.minus(-1, DAYS)), iso.minusDays(-1));
+        assertEquals(LocalDate.from(frenchRepublic.minus(-60, DAYS)), iso.minusDays(-60));
+    }
+
+    @Test(dataProvider = "samples")
+    public void test_until_DAYS(FrenchRepublicDate frenchRepublic, LocalDate iso) {
+        assertEquals(frenchRepublic.until(iso.plusDays(0), DAYS), 0);
+        assertEquals(frenchRepublic.until(iso.plusDays(1), DAYS), 1);
+        assertEquals(frenchRepublic.until(iso.plusDays(35), DAYS), 35);
+        assertEquals(frenchRepublic.until(iso.minusDays(40), DAYS), -40);
+    }
+
+    @DataProvider(name = "badDates")
+    Object[][] data_badDates() {
+        return new Object[][] {
+            {1, 0, 0},
+
+            {1, -1, 1},
+            {1, 0, 1},
+            {1, 14, 1},
+            {1, 15, 1},
+
+            {1, 1, -1},
+            {1, 1, 0},
+            {1, 1, 31},
+
+            {1, 2, -1},
+            {1, 2, 0},
+            {1, 2, 31},
+            {1, 2, 32},
+
+            {1, 13, -1},
+            {1, 13, 0},
+            {1, 13, 6},
+            {1, 13, 7},
+            {1, 13, 8},
+            {1, 13, 9},
+            {1, 13, 10},
+          
+            {3, 13, -1},
+            {3, 13, 0},
+            {3, 13, 7},
+            {3, 13, 8},
+            {3, 13, 9},
+            {3, 13, 10},
+
+            {1, 12, -1},
+            {1, 12, 0},
+            {1, 12, 31},
+            {1, 12, 32},
+          
+            {1, 3, 31},
+            {1, 4, 31},
+            {1, 5, 31},
+            {1, 6, 31},
+            {1, 7, 31},
+            {1, 8, 31},
+            {1, 9, 31},
+            {1, 10, 31},
+            {1, 11, 31},
+            {1, 12, 31},
+            {1, 13, 31},
+        };
+    }
+
+    @Test(dataProvider = "badDates", expectedExceptions = DateTimeException.class)
+    public void test_badDates(int year, int month, int dom) {
+        FrenchRepublicDate.of(year, month, dom);
+    }
+
+    @Test(expectedExceptions = DateTimeException.class)
+    public void test_chronology_dateYearDay_badDate() {
+        FrenchRepublicChronology.INSTANCE.dateYearDay(1, 366);
+    }
+
+    //-----------------------------------------------------------------------
+    // isLeapYear()
+    //-----------------------------------------------------------------------
+    @Test
+    public void test_isLeapYear_loop() {
+        for (int year = -200; year < 200; year++) {
+            FrenchRepublicDate base = FrenchRepublicDate.of(year, 1, 1);
+            assertEquals(base.isLeapYear(), ((year+1) % 4) == 0);
+            assertEquals(FrenchRepublicChronology.INSTANCE.isLeapYear(year), ((year+1) % 4) == 0);
+        }
+    }
+
+    @Test
+    public void test_isLeapYear_specific() {
+        assertEquals(FrenchRepublicChronology.INSTANCE.isLeapYear(1), false);
+        assertEquals(FrenchRepublicChronology.INSTANCE.isLeapYear(2), false);
+        assertEquals(FrenchRepublicChronology.INSTANCE.isLeapYear(3), true);
+        assertEquals(FrenchRepublicChronology.INSTANCE.isLeapYear(4), false);
+        assertEquals(FrenchRepublicChronology.INSTANCE.isLeapYear(5), false);
+        assertEquals(FrenchRepublicChronology.INSTANCE.isLeapYear(6), false);
+        assertEquals(FrenchRepublicChronology.INSTANCE.isLeapYear(7), true);
+        assertEquals(FrenchRepublicChronology.INSTANCE.isLeapYear(8), false);
+        assertEquals(FrenchRepublicChronology.INSTANCE.isLeapYear(9), false);
+        assertEquals(FrenchRepublicChronology.INSTANCE.isLeapYear(10), false);
+        assertEquals(FrenchRepublicChronology.INSTANCE.isLeapYear(11), true);
+        assertEquals(FrenchRepublicChronology.INSTANCE.isLeapYear(12), false);
+        assertEquals(FrenchRepublicChronology.INSTANCE.isLeapYear(13), false);
+        assertEquals(FrenchRepublicChronology.INSTANCE.isLeapYear(14), false);
+    }
+
+    @DataProvider(name = "lengthOfMonth")
+    Object[][] data_lengthOfMonth() {
+        return new Object[][] {
+            {1, 1, 30},
+            {1, 2, 30},
+            {1, 3, 30},
+            {1, 4, 30},
+            {1, 5, 30},
+            {1, 6, 30},
+            {1, 7, 30},
+            {1, 8, 30},
+            {1, 9, 30},
+            {1, 10, 30},
+            {1, 11, 30},
+            {1, 12, 30},            
+            {1, 13, 5},
+          
+            {1, 13, 5},
+            {2, 13, 5},
+            {3, 13, 6},
+            {4, 13, 5},
+            {5, 13, 5},
+            {6, 13, 5},
+            {7, 13, 6},
+            {8, 13, 5},
+            {9, 13, 5},
+            {10, 13, 5},
+            {11, 13, 6},
+            {12, 13, 5},
+            {13, 13, 5},
+            {14, 13, 5},
+        };
+    }
+
+    @Test(dataProvider = "lengthOfMonth")
+    public void test_lengthOfMonth(int year, int month, int length) {
+        assertEquals(FrenchRepublicDate.of(year, month, 1).lengthOfMonth(), length);
+    }
+
+    //-----------------------------------------------------------------------
+    // era, prolepticYear and dateYearDay
+    //-----------------------------------------------------------------------
+    @Test
+    public void test_era_loop() {
+        for (int year = -200; year < 200; year++) {
+            FrenchRepublicDate base = FrenchRepublicChronology.INSTANCE.date(year, 1, 1);
+            assertEquals(year, base.get(YEAR));
+            FrenchRepublicEra era = (year <= 0 ? FrenchRepublicEra.BEFORE_REPUBLICAN : FrenchRepublicEra.REPUBLICAN);
+            assertEquals(era, base.getEra());
+            int yoe = (year <= 0 ? 1 - year : year);
+            assertEquals(yoe, base.get(YEAR_OF_ERA));
+            FrenchRepublicDate eraBased = FrenchRepublicChronology.INSTANCE.date(era, yoe, 1, 1);
+            assertEquals(eraBased, base);
+        }
+    }
+
+    @Test
+    public void test_era_yearDay_loop() {
+        for (int year = -200; year < 200; year++) {
+            FrenchRepublicDate base = FrenchRepublicChronology.INSTANCE.dateYearDay(year, 1);
+            assertEquals(year, base.get(YEAR));
+            FrenchRepublicEra era = (year <= 0 ? FrenchRepublicEra.BEFORE_REPUBLICAN : FrenchRepublicEra.REPUBLICAN);
+            assertEquals(era, base.getEra());
+            int yoe = (year <= 0 ? 1 - year : year);
+            assertEquals(yoe, base.get(YEAR_OF_ERA));
+            FrenchRepublicDate eraBased = FrenchRepublicChronology.INSTANCE.dateYearDay(era, yoe, 1);
+            assertEquals(eraBased, base);
+        }
+    }
+
+    @Test
+    public void test_prolepticYear_specific() {
+        assertEquals(FrenchRepublicChronology.INSTANCE.prolepticYear(FrenchRepublicEra.REPUBLICAN, 4), 4);
+        assertEquals(FrenchRepublicChronology.INSTANCE.prolepticYear(FrenchRepublicEra.REPUBLICAN, 3), 3);
+        assertEquals(FrenchRepublicChronology.INSTANCE.prolepticYear(FrenchRepublicEra.REPUBLICAN, 2), 2);
+        assertEquals(FrenchRepublicChronology.INSTANCE.prolepticYear(FrenchRepublicEra.REPUBLICAN, 1), 1);
+        assertEquals(FrenchRepublicChronology.INSTANCE.prolepticYear(FrenchRepublicEra.BEFORE_REPUBLICAN, 1), 0);
+        assertEquals(FrenchRepublicChronology.INSTANCE.prolepticYear(FrenchRepublicEra.BEFORE_REPUBLICAN, 2), -1);
+        assertEquals(FrenchRepublicChronology.INSTANCE.prolepticYear(FrenchRepublicEra.BEFORE_REPUBLICAN, 3), -2);
+        assertEquals(FrenchRepublicChronology.INSTANCE.prolepticYear(FrenchRepublicEra.BEFORE_REPUBLICAN, 4), -3);
+    }
+
+    @Test(expectedExceptions = ClassCastException.class)
+    public void test_prolepticYear_badEra() {
+        FrenchRepublicChronology.INSTANCE.prolepticYear(IsoEra.CE, 4);
+    }
+
+    @Test
+    public void test_Chronology_eraOf() {
+        assertEquals(FrenchRepublicChronology.INSTANCE.eraOf(1), FrenchRepublicEra.REPUBLICAN);
+        assertEquals(FrenchRepublicChronology.INSTANCE.eraOf(0), FrenchRepublicEra.BEFORE_REPUBLICAN);
+    }
+
+    @Test(expectedExceptions = DateTimeException.class)
+    public void test_Chronology_eraOf_invalid() {
+        FrenchRepublicChronology.INSTANCE.eraOf(2);
+    }
+
+    @Test
+    public void test_Chronology_eras() {
+        List<Era> eras = FrenchRepublicChronology.INSTANCE.eras();
+        assertEquals(eras.size(), 2);
+        assertEquals(eras.contains(FrenchRepublicEra.BEFORE_REPUBLICAN), true);
+        assertEquals(eras.contains(FrenchRepublicEra.REPUBLICAN), true);
+    }
+
+    //-----------------------------------------------------------------------
+    // Chronology.range
+    //-----------------------------------------------------------------------
+    @Test
+    public void test_Chronology_range() {
+        assertEquals(FrenchRepublicChronology.INSTANCE.range(DAY_OF_WEEK), ValueRange.of(1, 10));
+        assertEquals(FrenchRepublicChronology.INSTANCE.range(DAY_OF_MONTH), ValueRange.of(1, 5, 30));
+        assertEquals(FrenchRepublicChronology.INSTANCE.range(DAY_OF_YEAR), ValueRange.of(1, 365, 366));
+        assertEquals(FrenchRepublicChronology.INSTANCE.range(MONTH_OF_YEAR), ValueRange.of(1, 13));
+    }
+
+    //-----------------------------------------------------------------------
+    // FrenchRepublicDate.range
+    //-----------------------------------------------------------------------
+    @DataProvider(name = "ranges")
+    Object[][] data_ranges() {
+        return new Object[][] {
+            {1, 1, 23, DAY_OF_MONTH, 1, 30},
+            {1, 2, 23, DAY_OF_MONTH, 1, 30},
+            {1, 3, 23, DAY_OF_MONTH, 1, 30},
+            {1, 4, 23, DAY_OF_MONTH, 1, 30},
+            {1, 5, 23, DAY_OF_MONTH, 1, 30},
+            {1, 6, 23, DAY_OF_MONTH, 1, 30},
+            {1, 7, 23, DAY_OF_MONTH, 1, 30},
+            {1, 8, 23, DAY_OF_MONTH, 1, 30},
+            {1, 9, 23, DAY_OF_MONTH, 1, 30},
+            {1, 10, 23, DAY_OF_MONTH, 1, 30},
+            {1, 11, 23, DAY_OF_MONTH, 1, 30},
+            {1, 12, 23, DAY_OF_MONTH, 1, 30},
+            {1, 13, 2, DAY_OF_MONTH, 1, 5},
+            {1, 1, 23, DAY_OF_YEAR, 1, 365},
+            {1, 1, 23, ALIGNED_WEEK_OF_MONTH, 1, 3},
+            {1, 12, 23, ALIGNED_WEEK_OF_MONTH, 1, 3},
+            {1, 13, 2, ALIGNED_WEEK_OF_MONTH, 1, 1},
+            
+            {3, 13, 2, DAY_OF_MONTH, 1, 6},
+            {3, 13, 2, DAY_OF_YEAR, 1, 366},
+            {3, 13, 2, ALIGNED_WEEK_OF_MONTH, 1, 1},
+            
+            {3, 2, 23, WeekFields.ISO.dayOfWeek(), 1, 10},
+
+        };
+    }
+
+    @Test(dataProvider = "ranges")
+    public void test_range(int year, int month, int dom, TemporalField field, int expectedMin, int expectedMax) {
+        assertEquals(FrenchRepublicDate.of(year, month, dom).range(field), ValueRange.of(expectedMin, expectedMax));
+    }
+
+    @Test(expectedExceptions = UnsupportedTemporalTypeException.class)
+    public void test_range_unsupported() {
+        FrenchRepublicDate.of(1, 6, 30).range(MINUTE_OF_DAY);
+    }
+
+    //-----------------------------------------------------------------------
+    // FrenchRepublicDate.getLong
+    //-----------------------------------------------------------------------
+    @DataProvider(name = "getLong")
+    Object[][] data_getLong() {
+        return new Object[][] {
+            {1, 6, 8, DAY_OF_WEEK, 8},
+            {1, 6, 8, DAY_OF_MONTH, 8},
+            {1, 6, 8, DAY_OF_YEAR, 30 * 5 + 8},
+            {1, 6, 8, ALIGNED_DAY_OF_WEEK_IN_MONTH, 8},
+            {1, 6, 8, ALIGNED_WEEK_OF_MONTH, 1},
+            {1, 6, 8, ALIGNED_DAY_OF_WEEK_IN_YEAR, 8},
+            {1, 6, 8, ALIGNED_WEEK_OF_YEAR, 16},
+            {1, 6, 8, MONTH_OF_YEAR, 6},
+            {1, 6, 8, PROLEPTIC_MONTH, 13 + 6 - 1},
+            {1, 6, 8, YEAR, 1},
+            {1, 6, 8, ERA, 1},
+            
+            {1, 6, 8, ERA, 1},
+            {0, 6, 8, ERA, 0},
+            
+            {1, 6, 8, WeekFields.ISO.dayOfWeek(), 8},
+        };
+    }
+
+    @Test(dataProvider = "getLong")
+    public void test_getLong(int year, int month, int dom, TemporalField field, long expected) {
+        assertEquals(FrenchRepublicDate.of(year, month, dom).getLong(field), expected);
+    }
+
+    @Test(expectedExceptions = UnsupportedTemporalTypeException.class)
+    public void test_getLong_unsupported() {
+        FrenchRepublicDate.of(1, 6, 30).getLong(MINUTE_OF_DAY);
+    }
+
+    //-----------------------------------------------------------------------
+    // FrenchRepublicDate.with
+    //-----------------------------------------------------------------------
+    @DataProvider(name = "with")
+    Object[][] data_with() {
+        return new Object[][] {
+            {1, 5, 26, DAY_OF_WEEK, 3, 1, 5, 23},
+            {1, 5, 26, DAY_OF_WEEK, 10, 1, 5, 30},
+            {1, 5, 26, DAY_OF_MONTH, 30, 1, 5, 30},
+            {1, 5, 26, DAY_OF_MONTH, 26, 1, 5, 26},
+            {1, 5, 26, DAY_OF_YEAR, 365, 1, 13, 5},
+            {1, 5, 26, DAY_OF_YEAR, 146, 1, 5, 26},
+            {1, 5, 26, ALIGNED_DAY_OF_WEEK_IN_MONTH, 3, 1, 5, 23},
+            {1, 5, 26, ALIGNED_DAY_OF_WEEK_IN_MONTH, 5, 1, 5, 25},
+            {1, 5, 26, ALIGNED_WEEK_OF_MONTH, 1, 1, 5, 6},
+            {1, 5, 26, ALIGNED_WEEK_OF_MONTH, 3, 1, 5, 26},
+            {1, 5, 26, ALIGNED_DAY_OF_WEEK_IN_YEAR, 2, 1, 5, 22},
+            {1, 5, 26, ALIGNED_DAY_OF_WEEK_IN_YEAR, 6, 1, 5, 26},
+            {1, 5, 26, ALIGNED_WEEK_OF_YEAR, 23, 1, 8, 16},
+            {1, 5, 26, ALIGNED_WEEK_OF_YEAR, 21, 1, 7, 26},
+            {1, 5, 26, MONTH_OF_YEAR, 7, 1, 7, 26},
+            {1, 5, 26, MONTH_OF_YEAR, 5, 1, 5, 26},
+            
+            {1, 5, 26, PROLEPTIC_MONTH, 3 * 13 + 3 - 1, 3, 3, 26},
+            {1, 5, 26, PROLEPTIC_MONTH, 4 * 13 + 5 - 1, 4, 5, 26},
+            {1, 5, 26, YEAR, 2, 2, 5, 26},
+            {1, 5, 26, YEAR, 3, 3, 5, 26},
+            {1, 5, 26, YEAR_OF_ERA, 2, 2, 5, 26},
+            {1, 5, 26, YEAR_OF_ERA, 3, 3, 5, 26},
+            //{1, 5, 26, ERA, 0, -1, 5, 26},
+            {1, 5, 26, ERA, 1, 1, 5, 26},
+
+            {1, 3, 30, MONTH_OF_YEAR, 13, 1, 13, 5},
+            {3, 3, 30, MONTH_OF_YEAR, 13, 3, 13, 6},
+            {1, 3, 30, MONTH_OF_YEAR, 6, 1, 6, 30},
+            {3, 13, 6, YEAR, 4, 4, 13, 5},
+            {-3, 6, 8, YEAR_OF_ERA, 2, -1, 6, 8},
+            //{1, 5, 26, WeekFields.ISO.dayOfWeek(), 3, 1, 5, 23},
+        };
+    }
+
+    @Test(dataProvider = "with")
+    public void test_with_TemporalField(int year, int month, int dom,
+            TemporalField field, long value,
+            int expectedYear, int expectedMonth, int expectedDom) {
+        assertEquals(FrenchRepublicDate.of(year, month, dom).with(field, value), FrenchRepublicDate.of(expectedYear, expectedMonth, expectedDom));
+    }
+
+    @Test(expectedExceptions = UnsupportedTemporalTypeException.class)
+    public void test_with_TemporalField_unsupported() {
+        FrenchRepublicDate.of(1, 6, 30).with(MINUTE_OF_DAY, 0);
+    }
+
+    //-----------------------------------------------------------------------
+    // FrenchRepublicDate.with(TemporalAdjuster)
+    //-----------------------------------------------------------------------
+    @Test
+    public void test_adjust1() {
+        FrenchRepublicDate base = FrenchRepublicDate.of(1, 6, 23);
+        FrenchRepublicDate test = base.with(TemporalAdjusters.lastDayOfMonth());
+        assertEquals(test, FrenchRepublicDate.of(1, 6, 30));
+    }
+
+    @Test
+    public void test_adjust2() {
+        FrenchRepublicDate base = FrenchRepublicDate.of(3, 13, 2);
+        FrenchRepublicDate test = base.with(TemporalAdjusters.lastDayOfMonth());
+        assertEquals(test, FrenchRepublicDate.of(3, 13, 6));
+    }
+
+    //-----------------------------------------------------------------------
+    // FrenchRepublicDate.with(Local*)
+    //-----------------------------------------------------------------------
+    @Test
+    public void test_adjust_toLocalDate() {
+        FrenchRepublicDate frenchRepublic = FrenchRepublicDate.of(1, 1, 4);
+        FrenchRepublicDate test = frenchRepublic.with(LocalDate.of(1793, 2, 28));
+        assertEquals(test, FrenchRepublicDate.of(1, 6, 10));
+    }
+
+    @Test(expectedExceptions = DateTimeException.class)
+    public void test_adjust_toMonth() {
+        FrenchRepublicDate frenchRepublic = FrenchRepublicDate.of(1, 1, 4);
+        frenchRepublic.with(Month.APRIL);
+    }
+
+    //-----------------------------------------------------------------------
+    // LocalDate.with(FrenchRepublicDate)
+    //-----------------------------------------------------------------------
+    @Test
+    public void test_LocalDate_adjustToFrenchRepublicDate() {
+        FrenchRepublicDate frenchRepublic = FrenchRepublicDate.of(1, 6, 10);
+        LocalDate test = LocalDate.MIN.with(frenchRepublic);
+        assertEquals(test, LocalDate.of(1793, 2, 28));
+    }
+
+    @Test
+    public void test_LocalDateTime_adjustToFrenchRepublicDate() {
+        FrenchRepublicDate frenchRepublic = FrenchRepublicDate.of(1, 6, 10);
+        LocalDateTime test = LocalDateTime.MIN.with(frenchRepublic);
+        assertEquals(test, LocalDateTime.of(1793, 2, 28, 0, 0));
+    }
+
+    //-----------------------------------------------------------------------
+    // FrenchRepublicDate.plus
+    //-----------------------------------------------------------------------
+    @DataProvider(name = "plus")
+    Object[][] data_plus() {
+        return new Object[][] {
+            {1, 5, 26, 0, DAYS, 1, 5, 26},
+            {1, 5, 26, 8, DAYS, 1, 6, 4},
+            {1, 5, 26, -3, DAYS, 1, 5, 23},
+            {1, 5, 26, 0, WEEKS, 1, 5, 26},
+            {1, 5, 26, 3, WEEKS, 1, 6, 26},
+            {1, 5, 26, -5, WEEKS, 1, 4, 6},
+            {1, 12, 25, 1, WEEKS, 1, 13, 5},
+            //{1, 12, 25, 2, WEEKS, 2, 1, 5},
+            //{1, 12, 25, 3, WEEKS, 2, 2, 5},
+            {1, 5, 26, 0, MONTHS, 1, 5, 26},
+            {1, 5, 26, 3, MONTHS, 1, 8, 26},
+            {2, 5, 5, -5, MONTHS, 1, 13, 5},
+            {1, 5, 26, 0, YEARS, 1, 5, 26},
+            {1, 5, 26, 3, YEARS, 4, 5, 26},
+            {13, 5, 26, -5, YEARS, 8, 5, 26},
+            {1, 5, 26, 0, DECADES, 1, 5, 26},
+            {1, 5, 26, 3, DECADES, 31, 5, 26},
+            {12, 5, 26, -1, DECADES, 2, 5, 26},
+            {1, 5, 26, 0, CENTURIES, 1, 5, 26},
+            {1, 5, 26, 3, CENTURIES, 301, 5, 26},
+            {501, 5, 26, -5, CENTURIES, 1, 5, 26},
+            {1, 5, 26, 0, MILLENNIA, 1, 5, 26},
+            {1, 5, 26, 3, MILLENNIA, 3001, 5, 26},
+            {5002, 5, 26, -5, MILLENNIA, 5002 - 5000, 5, 26},
+            //{2, 5, 26, -1, ERAS, -1, 5, 26},
+        };
+    }
+
+    @Test(dataProvider = "plus")
+    public void test_plus_TemporalUnit(int year, int month, int dom,
+            long amount, TemporalUnit unit,
+            int expectedYear, int expectedMonth, int expectedDom) {
+        assertEquals(FrenchRepublicDate.of(year, month, dom).plus(amount, unit), FrenchRepublicDate.of(expectedYear, expectedMonth, expectedDom));
+    }
+
+    @Test(dataProvider = "plus")
+    public void test_minus_TemporalUnit(
+            int expectedYear, int expectedMonth, int expectedDom,
+            long amount, TemporalUnit unit,
+            int year, int month, int dom) {
+        assertEquals(FrenchRepublicDate.of(year, month, dom).minus(amount, unit), FrenchRepublicDate.of(expectedYear, expectedMonth, expectedDom));
+    }
+
+    @Test(expectedExceptions = UnsupportedTemporalTypeException.class)
+    public void test_plus_TemporalUnit_unsupported() {
+        FrenchRepublicDate.of(2012, 6, 30).plus(0, MINUTES);
+    }
+
+    //-----------------------------------------------------------------------
+    // FrenchRepublicDate.until
+    //-----------------------------------------------------------------------
+    @DataProvider(name = "until")
+    Object[][] data_until() {
+        return new Object[][] {
+            {1, 5, 26, 1, 5, 26, DAYS, 0},
+            {1, 5, 26, 1, 6, 1, DAYS, 5},
+            {1, 5, 26, 1, 5, 20, DAYS, -6},
+            {1, 5, 26, 1, 5, 21, WEEKS, 0},
+            {1, 5, 26, 1, 5, 30, WEEKS, 0},
+            {1, 5, 26, 1, 6, 1, WEEKS, 0},
+            {1, 5, 26, 1, 6, 5, WEEKS, 0},
+            {1, 5, 26, 1, 6, 6, WEEKS, 1},
+            {1, 5, 26, 1, 5, 26, MONTHS, 0},
+            {1, 5, 26, 1, 6, 25, MONTHS, 0},
+            {1, 5, 26, 1, 6, 26, MONTHS, 1},
+            {1, 5, 26, 1, 5, 26, YEARS, 0},
+            {1, 5, 26, 2, 5, 25, YEARS, 0},
+            {1, 5, 26, 2, 5, 26, YEARS, 1},
+            {1, 5, 26, 1, 5, 26, DECADES, 0},
+            {1, 5, 26, 11, 5, 25, DECADES, 0},
+            {1, 5, 26, 11, 5, 26, DECADES, 1},
+            {1, 5, 26, 1, 5, 26, CENTURIES, 0},
+            {1, 5, 26, 101, 5, 25, CENTURIES, 0},
+            {1, 5, 26, 101, 5, 26, CENTURIES, 1},
+            {1, 5, 26, 1, 5, 26, MILLENNIA, 0},
+            {1, 5, 26, 1001, 5, 25, MILLENNIA, 0},
+            {1, 5, 26, 1001, 5, 26, MILLENNIA, 1},
+            /*{-2013, 5, 26, 0, 5, 26, ERAS, 0},
+            {-2013, 5, 26, 2014, 5, 26, ERAS, 1},*/
+        };
+    }
+
+    @Test(dataProvider = "until")
+    public void test_until_TemporalUnit(
+            int year1, int month1, int dom1,
+            int year2, int month2, int dom2,
+            TemporalUnit unit, long expected) {
+        FrenchRepublicDate start = FrenchRepublicDate.of(year1, month1, dom1);
+        FrenchRepublicDate end = FrenchRepublicDate.of(year2, month2, dom2);
+        assertEquals(start.until(end, unit), expected);
+    }
+
+    @Test(expectedExceptions = UnsupportedTemporalTypeException.class)
+    public void test_until_TemporalUnit_unsupported() {
+        FrenchRepublicDate start = FrenchRepublicDate.of(2012, 6, 30);
+        FrenchRepublicDate end = FrenchRepublicDate.of(2012, 7, 1);
+        start.until(end, MINUTES);
+    }
+
+    //-----------------------------------------------------------------------
+    @Test
+    public void test_plus_Period() {
+        assertEquals(FrenchRepublicDate.of(1, 5, 26).plus(FrenchRepublicChronology.INSTANCE.period(0, 2, 3)), FrenchRepublicDate.of(1, 7, 29));
+    }
+
+    @Test(expectedExceptions = DateTimeException.class)
+    public void test_plus_Period_ISO() {
+        assertEquals(FrenchRepublicDate.of(1, 5, 26).plus(Period.ofMonths(2)), FrenchRepublicDate.of(1, 7, 26));
+    }
+
+    @Test
+    public void test_minus_Period() {
+        assertEquals(FrenchRepublicDate.of(1, 5, 26).minus(FrenchRepublicChronology.INSTANCE.period(0, 2, 3)), FrenchRepublicDate.of(1, 3, 23));
+    }
+
+    @Test(expectedExceptions = DateTimeException.class)
+    public void test_minus_Period_ISO() {
+        assertEquals(FrenchRepublicDate.of(1, 5, 26).minus(Period.ofMonths(2)), FrenchRepublicDate.of(1, 3, 26));
+    }
+
+    //-----------------------------------------------------------------------
+    // equals()
+    //-----------------------------------------------------------------------
+    @Test
+    void test_equals() {
+        FrenchRepublicDate a1 = FrenchRepublicDate.of(1, 1, 3);
+        FrenchRepublicDate a2 = FrenchRepublicDate.of(1, 1, 3);
+        FrenchRepublicDate b = FrenchRepublicDate.of(1, 1, 4);
+        FrenchRepublicDate c = FrenchRepublicDate.of(1, 2, 3);
+        FrenchRepublicDate d = FrenchRepublicDate.of(2, 1, 3);
+
+        assertEquals(a1.equals(a1), true);
+        assertEquals(a1.equals(a2), true);
+        assertEquals(a1.equals(b), false);
+        assertEquals(a1.equals(c), false);
+        assertEquals(a1.equals(d), false);
+
+        assertEquals(a1.equals(null), false);
+        assertEquals(a1.equals(""), false);
+
+        assertEquals(a1.hashCode(), a2.hashCode());
+    }
+
+    //-----------------------------------------------------------------------
+    // toString()
+    //-----------------------------------------------------------------------
+    @DataProvider(name = "toString")
+    Object[][] data_toString() {
+        return new Object[][] {
+            {FrenchRepublicDate.of(1, 1, 1), "French Republican REPUBLICAN 1-01-01"},
+            {FrenchRepublicDate.of(14, 13, 5), "French Republican REPUBLICAN 14-13-05"},
+        };
+    }
+
+    @Test(dataProvider = "toString")
+    public void test_toString(FrenchRepublicDate frenchRepublic, String expected) {
+        assertEquals(frenchRepublic.toString(), expected);
+    }
+
+}

--- a/src/test/java/org/threeten/extra/chrono/TestFrenchRepublicChronology.java
+++ b/src/test/java/org/threeten/extra/chrono/TestFrenchRepublicChronology.java
@@ -330,7 +330,9 @@ public class TestFrenchRepublicChronology {
     @Test
     public void test_isLeapYear_loop() {
         for (int year = -200; year < 200; year++) {
-            assertEquals(FrenchRepublicChronology.INSTANCE.isLeapYear(year), ((year + 1) & 3) == 0);
+            FrenchRepublicDate base = FrenchRepublicDate.of(year, 1, 1);
+            assertEquals(base.isLeapYear(), ((year+1) % 4) == 0);
+            assertEquals(FrenchRepublicChronology.INSTANCE.isLeapYear(year), ((year+1) % 4) == 0);
         }
     }
 

--- a/src/test/java/org/threeten/extra/chrono/TestFrenchRepublicChronology.java
+++ b/src/test/java/org/threeten/extra/chrono/TestFrenchRepublicChronology.java
@@ -330,9 +330,7 @@ public class TestFrenchRepublicChronology {
     @Test
     public void test_isLeapYear_loop() {
         for (int year = -200; year < 200; year++) {
-            FrenchRepublicDate base = FrenchRepublicDate.of(year, 1, 1);
-            assertEquals(base.isLeapYear(), ((year+1) % 4) == 0);
-            assertEquals(FrenchRepublicChronology.INSTANCE.isLeapYear(year), ((year+1) % 4) == 0);
+            assertEquals(FrenchRepublicChronology.INSTANCE.isLeapYear(year), ((year + 1) & 3) == 0);
         }
     }
 

--- a/src/test/java/org/threeten/extra/chrono/TestFrenchRepublicChronology.java
+++ b/src/test/java/org/threeten/extra/chrono/TestFrenchRepublicChronology.java
@@ -54,6 +54,9 @@ import static java.time.temporal.ChronoUnit.MONTHS;
 import static java.time.temporal.ChronoUnit.WEEKS;
 import static java.time.temporal.ChronoUnit.YEARS;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
 
 import java.time.DateTimeException;
 import java.time.LocalDate;
@@ -63,13 +66,11 @@ import java.time.Period;
 import java.time.chrono.Chronology;
 import java.time.chrono.Era;
 import java.time.chrono.IsoEra;
-import java.time.temporal.IsoFields;
 import java.time.temporal.TemporalAdjusters;
 import java.time.temporal.TemporalField;
 import java.time.temporal.TemporalUnit;
 import java.time.temporal.UnsupportedTemporalTypeException;
 import java.time.temporal.ValueRange;
-import java.time.temporal.WeekFields;
 import java.util.List;
 
 import org.testng.Assert;
@@ -113,7 +114,6 @@ public class TestFrenchRepublicChronology {
             {FrenchRepublicDate.of(1, 1, 2), LocalDate.of(1792, 9, 23)},
             {FrenchRepublicDate.of(1, 1, 3), LocalDate.of(1792, 9, 24)},
             {FrenchRepublicDate.of(1, 1, 30), LocalDate.of(1792, 10, 21)},
-
             {FrenchRepublicDate.of(1, 4, 11), LocalDate.of(1792, 12, 31)},
             {FrenchRepublicDate.of(1, 4, 12), LocalDate.of(1793, 1, 1)},
             {FrenchRepublicDate.of(1, 6, 10), LocalDate.of(1793, 2, 28)},
@@ -203,8 +203,6 @@ public class TestFrenchRepublicChronology {
         assertEquals(FrenchRepublicDate.from(iso), french);
     }
 
-
-
     @Test(dataProvider = "samples")
     public void test_FrenchRepublicDate_chronology_dateEpochDay(FrenchRepublicDate frenchRepublic, LocalDate iso) {
         assertEquals(FrenchRepublicChronology.INSTANCE.dateEpochDay(iso.toEpochDay()), frenchRepublic);
@@ -241,7 +239,7 @@ public class TestFrenchRepublicChronology {
         assertEquals(LocalDate.from(frenchRepublic.plus(1, DAYS)), iso.plusDays(1));
         assertEquals(LocalDate.from(frenchRepublic.plus(35, DAYS)), iso.plusDays(35));
         assertEquals(LocalDate.from(frenchRepublic.plus(-1, DAYS)), iso.plusDays(-1));
-        assertEquals(LocalDate.from(frenchRepublic.plus(-60, DAYS)), iso.plusDays(-60));
+        assertEquals(LocalDate.from(frenchRepublic.plus(-59, DAYS)), iso.plusDays(-59));
     }
 
     @Test(dataProvider = "samples")
@@ -250,7 +248,7 @@ public class TestFrenchRepublicChronology {
         assertEquals(LocalDate.from(frenchRepublic.minus(1, DAYS)), iso.minusDays(1));
         assertEquals(LocalDate.from(frenchRepublic.minus(35, DAYS)), iso.minusDays(35));
         assertEquals(LocalDate.from(frenchRepublic.minus(-1, DAYS)), iso.minusDays(-1));
-        assertEquals(LocalDate.from(frenchRepublic.minus(-60, DAYS)), iso.minusDays(-60));
+        assertEquals(LocalDate.from(frenchRepublic.minus(-57, DAYS)), iso.minusDays(-57));
     }
 
     @Test(dataProvider = "samples")
@@ -369,22 +367,22 @@ public class TestFrenchRepublicChronology {
             {1, 10, 30},
             {1, 11, 30},
             {1, 12, 30},
-            {1, 13, 5},
+            {1, 13, 0},
 
-            {1, 13, 5},
-            {2, 13, 5},
-            {3, 13, 6},
-            {4, 13, 5},
-            {5, 13, 5},
-            {6, 13, 5},
-            {7, 13, 6},
-            {8, 13, 5},
-            {9, 13, 5},
-            {10, 13, 5},
-            {11, 13, 6},
-            {12, 13, 5},
-            {13, 13, 5},
-            {14, 13, 5},
+            {1, 13, 0},
+            {2, 13, 0},
+            {3, 13, 0},
+            {4, 13, 0},
+            {5, 13, 0},
+            {6, 13, 0},
+            {7, 13, 0},
+            {8, 13, 0},
+            {9, 13, 0},
+            {10, 13, 0},
+            {11, 13, 0},
+            {12, 13, 0},
+            {13, 13, 0},
+            {14, 13, 0},
         };
     }
 
@@ -489,15 +487,15 @@ public class TestFrenchRepublicChronology {
             {1, 10, 23, DAY_OF_MONTH, 1, 30},
             {1, 11, 23, DAY_OF_MONTH, 1, 30},
             {1, 12, 23, DAY_OF_MONTH, 1, 30},
-            {1, 13, 2, DAY_OF_MONTH, 1, 5},
+            {1, 13, 2, DAY_OF_MONTH, 0, 0},
             {1, 1, 23, DAY_OF_YEAR, 1, 365},
             {1, 1, 23, ALIGNED_WEEK_OF_MONTH, 1, 3},
             {1, 12, 23, ALIGNED_WEEK_OF_MONTH, 1, 3},
-            {1, 13, 2, ALIGNED_WEEK_OF_MONTH, 1, 1},
+            {1, 13, 2, ALIGNED_WEEK_OF_MONTH, 0, 0},
 
-            {3, 13, 2, DAY_OF_MONTH, 1, 6},
+            {3, 13, 2, DAY_OF_MONTH, 0, 0},
             {3, 13, 2, DAY_OF_YEAR, 1, 366},
-            {3, 13, 2, ALIGNED_WEEK_OF_MONTH, 1, 1},
+            {3, 13, 2, ALIGNED_WEEK_OF_MONTH, 0, 0},
         };
     }
 
@@ -525,7 +523,7 @@ public class TestFrenchRepublicChronology {
             {1, 6, 8, ALIGNED_DAY_OF_WEEK_IN_YEAR, 8},
             {1, 6, 8, ALIGNED_WEEK_OF_YEAR, 16},
             {1, 6, 8, MONTH_OF_YEAR, 6},
-            {1, 6, 8, PROLEPTIC_MONTH, 13 + 6 - 1},
+            {1, 6, 8, PROLEPTIC_MONTH, 12 + 6 - 1},
             {1, 6, 8, YEAR, 1},
             {1, 6, 8, ERA, 1},
 
@@ -567,13 +565,13 @@ public class TestFrenchRepublicChronology {
             {1, 5, 26, MONTH_OF_YEAR, 7, 1, 7, 26},
             {1, 5, 26, MONTH_OF_YEAR, 5, 1, 5, 26},
 
-            {1, 5, 26, PROLEPTIC_MONTH, 3 * 13 + 3 - 1, 3, 3, 26},
-            {1, 5, 26, PROLEPTIC_MONTH, 4 * 13 + 5 - 1, 4, 5, 26},
+            {1, 5, 26, PROLEPTIC_MONTH, 3 * 12 + 3 - 1, 3, 3, 26},
+            {1, 5, 26, PROLEPTIC_MONTH, 4 * 12 + 5 - 1, 4, 5, 26},
             {1, 5, 26, YEAR, 2, 2, 5, 26},
             {1, 5, 26, YEAR, 3, 3, 5, 26},
             {1, 5, 26, YEAR_OF_ERA, 2, 2, 5, 26},
             {1, 5, 26, YEAR_OF_ERA, 3, 3, 5, 26},
-            //{1, 5, 26, ERA, 0, -1, 5, 26},
+            {1, 5, 26, ERA, 0, 0, 5, 26},
             {1, 5, 26, ERA, 1, 1, 5, 26},
 
             {1, 3, 30, MONTH_OF_YEAR, 13, 1, 13, 5},
@@ -608,9 +606,9 @@ public class TestFrenchRepublicChronology {
 
     @Test
     public void test_adjust2() {
-        FrenchRepublicDate base = FrenchRepublicDate.of(3, 13, 2);
+        FrenchRepublicDate base = FrenchRepublicDate.of(3, 12, 2);
         FrenchRepublicDate test = base.with(TemporalAdjusters.lastDayOfMonth());
-        assertEquals(test, FrenchRepublicDate.of(3, 13, 6));
+        assertEquals(test, FrenchRepublicDate.of(3, 12, 30));
     }
 
     //-----------------------------------------------------------------------
@@ -658,12 +656,14 @@ public class TestFrenchRepublicChronology {
             {1, 5, 26, 0, WEEKS, 1, 5, 26},
             {1, 5, 26, 3, WEEKS, 1, 6, 26},
             {1, 5, 26, -5, WEEKS, 1, 4, 6},
-            {1, 12, 25, 1, WEEKS, 1, 13, 5},
-            //{1, 12, 25, 2, WEEKS, 2, 1, 5},
-            //{1, 12, 25, 3, WEEKS, 2, 2, 5},
+            {1, 12, 25, 1, WEEKS, 2, 1, 5},
+            {1, 12, 25, 2, WEEKS, 2, 1, 15},
+            {1, 12, 25, 3, WEEKS, 2, 1, 25},
+            {1, 13, 5, 72, WEEKS, 3, 13, 5},
             {1, 5, 26, 0, MONTHS, 1, 5, 26},
             {1, 5, 26, 3, MONTHS, 1, 8, 26},
-            {2, 5, 5, -5, MONTHS, 1, 13, 5},
+            {2, 5, 5, -5, MONTHS, 1, 12, 5},
+            {1, 13, 5, 12, MONTHS, 2, 13, 5},
             {1, 5, 26, 0, YEARS, 1, 5, 26},
             {1, 5, 26, 3, YEARS, 4, 5, 26},
             {13, 5, 26, -5, YEARS, 8, 5, 26},
@@ -676,12 +676,13 @@ public class TestFrenchRepublicChronology {
             {1, 5, 26, 0, MILLENNIA, 1, 5, 26},
             {1, 5, 26, 3, MILLENNIA, 3001, 5, 26},
             {5002, 5, 26, -5, MILLENNIA, 5002 - 5000, 5, 26},
-            //{2, 5, 26, -1, ERAS, -1, 5, 26},
+            {2, 5, 26, -1, ERAS, -1, 5, 26},
         };
     }
 
     @Test(dataProvider = "plus")
-    public void test_plus_TemporalUnit(int year, int month, int dom,
+    public void test_plus_TemporalUnit(
+            int year, int month, int dom,
             long amount, TemporalUnit unit,
             int expectedYear, int expectedMonth, int expectedDom) {
         assertEquals(FrenchRepublicDate.of(year, month, dom).plus(amount, unit), FrenchRepublicDate.of(expectedYear, expectedMonth, expectedDom));
@@ -697,7 +698,7 @@ public class TestFrenchRepublicChronology {
 
     @Test(expectedExceptions = UnsupportedTemporalTypeException.class)
     public void test_plus_TemporalUnit_unsupported() {
-        FrenchRepublicDate.of(2012, 6, 30).plus(0, MINUTES);
+        FrenchRepublicDate.of(2012, 6, 30).plus(1, MINUTES);
     }
 
     //-----------------------------------------------------------------------
@@ -783,14 +784,15 @@ public class TestFrenchRepublicChronology {
         FrenchRepublicDate c = FrenchRepublicDate.of(1, 2, 3);
         FrenchRepublicDate d = FrenchRepublicDate.of(2, 1, 3);
 
-        assertEquals(a1.equals(a1), true);
-        assertEquals(a1.equals(a2), true);
-        assertEquals(a1.equals(b), false);
-        assertEquals(a1.equals(c), false);
-        assertEquals(a1.equals(d), false);
+        assertNotNull(a1);
+        assertTrue(a1.equals(a1));
+        assertTrue(a1.equals(a2));
+        assertFalse(a1.equals(b));
+        assertFalse(a1.equals(c));
+        assertFalse(a1.equals(d));
 
-        assertEquals(a1.equals(null), false);
-        assertEquals(a1.equals(""), false);
+        assertFalse(a1.equals(null));
+        assertFalse(a1.equals(""));
 
         assertEquals(a1.hashCode(), a2.hashCode());
     }
@@ -803,6 +805,7 @@ public class TestFrenchRepublicChronology {
         return new Object[][] {
             {FrenchRepublicDate.of(1, 1, 1), "French Republican REPUBLICAN 1-01-01"},
             {FrenchRepublicDate.of(14, 13, 5), "French Republican REPUBLICAN 14-13-05"},
+            {FrenchRepublicDate.of(0, 5, 5), "French Republican BEFORE_REPUBLICAN 1-05-05"},
         };
     }
 


### PR DESCRIPTION
This PR brings lots of small a some bigger improvements.

All commented test data cases are fixed.
Week calculation does not involve the supplementary days.
In fact, these days are explicitly excluded from dealing with weeks and months.

You can, however, add add multiple of 36 weeks or multiple of 12 months to the supplementary days, as this constitutes to add full years.  The same is true for subtraction.

There is no benefit in extending from AbstractNile* classes.
One more change I'd like to introduce is to consider the supplementary days as artificial month 0, rather than 13, this conveys the idea that it is only an internal, hence artificial month.