### PR TITLE
Improvements to ranges, calculation

### DIFF
--- a/src/main/java/org/threeten/extra/chrono/FrenchRepublicChronology.java
+++ b/src/main/java/org/threeten/extra/chrono/FrenchRepublicChronology.java
@@ -69,6 +69,10 @@ public final class FrenchRepublicChronology
     private static final long serialVersionUID = 7291205177830286973L;
 
     /**
+     * Empty range
+     */
+    static final ValueRange EMPTY = ValueRange.of(0, 0);
+    /**
      * Range of days of week.
      */
     static final ValueRange DOW_RANGE = ValueRange.of(1, 10);

--- a/src/main/java/org/threeten/extra/chrono/FrenchRepublicChronology.java
+++ b/src/main/java/org/threeten/extra/chrono/FrenchRepublicChronology.java
@@ -36,6 +36,7 @@ import java.time.Clock;
 import java.time.DateTimeException;
 import java.time.Instant;
 import java.time.ZoneId;
+import java.time.chrono.AbstractChronology;
 import java.time.chrono.ChronoLocalDateTime;
 import java.time.chrono.ChronoZonedDateTime;
 import java.time.chrono.Era;
@@ -46,7 +47,6 @@ import static java.time.temporal.ChronoField.DAY_OF_WEEK;
 import java.time.temporal.TemporalAccessor;
 import java.time.temporal.TemporalField;
 import java.time.temporal.ValueRange;
-import java.time.temporal.WeekFields;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
@@ -55,8 +55,8 @@ import java.util.Map;
 
  */
 public final class FrenchRepublicChronology
-        extends AbstractNileChronology
-        implements Serializable {
+    extends AbstractChronology
+    implements Serializable {
 
     /**
      * Singleton instance for the FrenchRepublic chronology.
@@ -82,11 +82,48 @@ public final class FrenchRepublicChronology
     static final ValueRange ALIGNED_WOM_RANGE = ValueRange.of(1, 1, 3);
 
     /**
+     * Range of proleptic-year.
+     */
+    static final ValueRange YEAR_RANGE = ValueRange.of(-999_998, 999_999);
+    /**
+     * Range of year.
+     */
+    static final ValueRange YOE_RANGE = ValueRange.of(1, 999_999);
+    /**
+     * Range of proleptic month.
+     */
+    static final ValueRange PROLEPTIC_MONTH_RANGE = ValueRange.of(-999_998L * 12, 999_999L * 12L + 11);
+    /**
+     * Range of months.
+     */
+    static final ValueRange MOY_RANGE = ValueRange.of(1, 13);
+    /**
+     * Range of days.
+     */
+    static final ValueRange DOM_RANGE = ValueRange.of(1, 30);
+
+    /**
      * Private constructor, that is public to satisfy the {@code ServiceLoader}.
      * @deprecated Use the singleton {@link #INSTANCE} instead.
      */
     @Deprecated
     public FrenchRepublicChronology() {
+    }
+
+    //-----------------------------------------------------------------------
+    /**
+     * Checks if the specified year is a leap year.
+     * <p>
+     * The proleptic-year is leap if the remainder after division by four equals three.
+     * This method does not validate the year passed in, and only has a
+     * well-defined result for years in the supported range.
+     *
+     * @param prolepticYear  the proleptic-year to check, not validated for range
+     * @return true if the year is a leap year
+     */
+    @Override
+    public boolean isLeapYear(long prolepticYear) {
+        return (prolepticYear & 3) == 3;
     }
 
     /**
@@ -310,12 +347,25 @@ public final class FrenchRepublicChronology
 
     @Override
     public ValueRange range(ChronoField field) {
-        if (field == DAY_OF_WEEK) {
-            return DOW_RANGE;
-        } else if (field == ALIGNED_WEEK_OF_MONTH) {
-            return ALIGNED_WOM_RANGE;
+        switch (field) {
+            case DAY_OF_WEEK:
+                return DOW_RANGE;
+            case DAY_OF_MONTH:
+                return DOM_RANGE;
+            case ALIGNED_WEEK_OF_MONTH:
+                return ALIGNED_WOM_RANGE;
+            case MONTH_OF_YEAR:
+                return MOY_RANGE;
+            case PROLEPTIC_MONTH:
+                return PROLEPTIC_MONTH_RANGE;
+            case YEAR_OF_ERA:
+                return YOE_RANGE;
+            case YEAR:
+                return YEAR_RANGE;
+            default:
+                break;
         }
-        return super.range(field);
+        return field.range();
     }
 
     //-----------------------------------------------------------------------

--- a/src/main/java/org/threeten/extra/chrono/FrenchRepublicDate.java
+++ b/src/main/java/org/threeten/extra/chrono/FrenchRepublicDate.java
@@ -301,9 +301,9 @@ public final class FrenchRepublicDate
     static FrenchRepublicDate ofEpochDay(final long epochDay) {
         EPOCH_DAY.range().checkValidValue(epochDay, EPOCH_DAY);  // validate outer bounds
         // use of French Republican year - 1 places leap year at the end of cycle
-        long frenchRevEpochDayPlus365 = epochDay + EPOCH_DAY_DIFFERENCE + 365;
-        long cycle = Math.floorDiv(frenchRevEpochDayPlus365, DAYS_PER_CYCLE);
-        long daysInCycle = Math.floorMod(frenchRevEpochDayPlus365, DAYS_PER_CYCLE);
+        long epochDays = epochDay + EPOCH_DAY_DIFFERENCE + 365;
+        long cycle = Math.floorDiv(epochDays, DAYS_PER_CYCLE);
+        long daysInCycle = Math.floorMod(epochDays, DAYS_PER_CYCLE);
         if (daysInCycle == DAYS_PER_CYCLE - 1) {
             int year = (int) (cycle * 4 + 3);
             return ofYearDay(year, 366);

--- a/src/main/java/org/threeten/extra/chrono/FrenchRepublicDate.java
+++ b/src/main/java/org/threeten/extra/chrono/FrenchRepublicDate.java
@@ -300,7 +300,7 @@ public final class FrenchRepublicDate
      */
     static FrenchRepublicDate ofEpochDay(final long epochDay) {
         EPOCH_DAY.range().checkValidValue(epochDay, EPOCH_DAY);  // validate outer bounds
-        // use of French Rev. -1 makes leap year at the end of cycle
+        // use of French Republican year - 1 places leap year at the end of cycle
         long frenchRevEpochDayPlus365 = epochDay + EPOCH_DAY_DIFFERENCE + 365;
         long cycle = Math.floorDiv(frenchRevEpochDayPlus365, DAYS_PER_CYCLE);
         long daysInCycle = Math.floorMod(frenchRevEpochDayPlus365, DAYS_PER_CYCLE);
@@ -358,8 +358,8 @@ public final class FrenchRepublicDate
         this.prolepticYear = prolepticYear;
         this.month = month;
         this.day = dayOfMonth;
-        long calendarEpochDay = (prolepticYear * 365) + Math.floorDiv(prolepticYear, 4) + (getDayOfYear() - 1);
-        this.epochDay = calendarEpochDay - 365 - EPOCH_DAY_DIFFERENCE;
+        this.epochDay = ((prolepticYear - 1) * 365) + Math.floorDiv(prolepticYear, 4) +
+                (getDayOfYear() - 1) - EPOCH_DAY_DIFFERENCE;
     }
 
     /**

--- a/src/main/java/org/threeten/extra/chrono/FrenchRepublicDate.java
+++ b/src/main/java/org/threeten/extra/chrono/FrenchRepublicDate.java
@@ -32,7 +32,6 @@
 package org.threeten.extra.chrono;
 
 import static java.time.temporal.ChronoField.DAY_OF_MONTH;
-import static java.time.temporal.ChronoField.DAY_OF_WEEK;
 import static java.time.temporal.ChronoField.DAY_OF_YEAR;
 import static java.time.temporal.ChronoField.EPOCH_DAY;
 import static java.time.temporal.ChronoField.MONTH_OF_YEAR;
@@ -55,9 +54,9 @@ import java.time.temporal.TemporalAmount;
 import java.time.temporal.TemporalField;
 import java.time.temporal.TemporalQuery;
 import java.time.temporal.TemporalUnit;
+import java.time.temporal.UnsupportedTemporalTypeException;
 import java.time.temporal.ValueRange;
-import java.time.temporal.WeekFields;
-import static org.threeten.extra.chrono.FrenchRepublicChronology.DOW_RANGE;
+
 
 /**
  * A date in the FrenchRepublic calendar system.
@@ -74,7 +73,7 @@ import static org.threeten.extra.chrono.FrenchRepublicChronology.DOW_RANGE;
  * identity hash code or use the distinction between equals() and ==.
  */
 public final class FrenchRepublicDate
-        extends AbstractNileDate
+        extends AbstractDate
         implements ChronoLocalDate, Serializable {
 
     /**
@@ -98,11 +97,15 @@ public final class FrenchRepublicDate
     /**
      * The month.
      */
-    private final short month;
+    private final int month;
     /**
      * The day.
      */
-    private final short day;
+    private final int day;
+    /**
+     * Epoch day
+     */
+    private final long epochDay;
 
     //-----------------------------------------------------------------------
     /**
@@ -196,13 +199,16 @@ public final class FrenchRepublicDate
 
     @Override
     ValueRange rangeAlignedWeekOfMonth() {
-        return ValueRange.of(1, getMonth() == 13 ? 1 : 3);
+        return ValueRange.of(getMonth() != 13 ? 1 : 0, getMonth() != 13 ? 3 : 0);
     }
 
 
     @Override
     int getDayOfWeek() {
-        return (int) Math.floorMod(day, 10);
+        if (month == 13) {
+            return 0;
+        }
+        return Math.floorMod(day, 10);
     }
 
     @Override
@@ -210,8 +216,57 @@ public final class FrenchRepublicDate
         return 10;
     }
 
+    @Override
+    public int lengthOfMonth() {
+        if (getMonth() != 13) {
+            return 30;
+        }
+        return 0;
+    }
 
+    @Override
+    int lengthOfYearInMonths() {
+        return 12;
+    }
 
+    @Override
+    int getDayOfYear() {
+        return (getMonth() - 1) * 30 + getDayOfMonth();
+    }
+
+    @Override
+    public ValueRange range(TemporalField field) {
+        if (field instanceof ChronoField) {
+            if (isSupported(field)) {
+                ChronoField f = (ChronoField) field;
+                switch (f) {
+                    case ALIGNED_DAY_OF_WEEK_IN_MONTH:
+                    case ALIGNED_DAY_OF_WEEK_IN_YEAR:
+                    case DAY_OF_WEEK:
+                        return month != 13 ? FrenchRepublicChronology.DOW_RANGE : FrenchRepublicChronology.EMPTY;
+                    case ALIGNED_WEEK_OF_MONTH:
+                        return month != 13 ? ValueRange.of(1, 3) : FrenchRepublicChronology.EMPTY;
+                    case ALIGNED_WEEK_OF_YEAR:
+                        return month != 13 ? ValueRange.of(1, 36) : FrenchRepublicChronology.EMPTY;
+                    case DAY_OF_MONTH:
+                        return month != 13 ? ValueRange.of(1, lengthOfMonth()) : FrenchRepublicChronology.EMPTY;
+                    case DAY_OF_YEAR:
+                        return isLeapYear() ? ValueRange.of(1, 366) : ValueRange.of(1, 365);
+                    //case EPOCH_DAY:
+                    //    return ValueRange.of(-999_999, 999_999);
+                    //case ERA:
+                    //    return ERA_RANGE;
+                    case MONTH_OF_YEAR:
+                        return ValueRange.of(1, 12);
+                    default:
+                        break;
+                }
+            } else {
+                throw new UnsupportedTemporalTypeException("Unsupported field: " + field);
+            }
+        }
+        return super.range(field);
+    }
     //-----------------------------------------------------------------------
     /**
      * Obtains a {@code FrenchRepublicDate} representing a date in the FrenchRepublic calendar
@@ -301,8 +356,10 @@ public final class FrenchRepublicDate
      */
     private FrenchRepublicDate(int prolepticYear, int month, int dayOfMonth) {
         this.prolepticYear = prolepticYear;
-        this.month = (short) month;
-        this.day = (short) dayOfMonth;
+        this.month = month;
+        this.day = dayOfMonth;
+        long calendarEpochDay = (prolepticYear * 365) + Math.floorDiv(prolepticYear, 4) + (getDayOfYear() - 1);
+        this.epochDay = calendarEpochDay - 365 - EPOCH_DAY_DIFFERENCE;
     }
 
     /**
@@ -315,10 +372,6 @@ public final class FrenchRepublicDate
     }
 
     //-----------------------------------------------------------------------
-    @Override
-    int getEpochDayDifference() {
-        return EPOCH_DAY_DIFFERENCE;
-    }
 
     @Override
     int getProlepticYear() {
@@ -333,6 +386,10 @@ public final class FrenchRepublicDate
     @Override
     int getDayOfMonth() {
         return day;
+    }
+
+    private long getProlepticWeek() {
+        return getProlepticMonth() * 3 + ((getDayOfMonth() - 1) / 10) - 1;
     }
 
     @Override
@@ -357,7 +414,7 @@ public final class FrenchRepublicDate
     /**
      * Gets the era applicable at this date.
      * <p>
-     * The FrenchRepublic calendar system has two eras, 'AM' and 'BEFORE_AM',
+     * The FrenchRepublic calendar system has two eras, 'REPUBLICAN' and 'BEFORE_REPUBLICAN',
      * defined by {@link FrenchRepublicEra}.
      *
      * @return the era applicable at this date, not null
@@ -389,6 +446,44 @@ public final class FrenchRepublicDate
         return (FrenchRepublicDate) super.plus(amountToAdd, unit);
     }
 
+    /*
+    */
+    @Override
+    FrenchRepublicDate plusMonths(long months) {
+        if (months % 12 == 0) {
+            return (FrenchRepublicDate) plusYears(months / 12);
+        }
+        if (month == 13 || 0 == months) {
+            return this;
+        }
+        return (FrenchRepublicDate) super.plusMonths(months);
+    }
+
+    @Override
+    FrenchRepublicDate plusWeeks(long weeks) {
+        if (weeks % 3 == 0) {
+            return plusMonths(weeks / 3);
+        }
+        if (month == 13 || 0 == weeks) {
+            return this;
+        }
+        long curEm = getProlepticWeek();
+        long calcEm = Math.addExact(curEm, weeks) + 1;
+        int newYear = Math.toIntExact(Math.floorDiv(calcEm, lengthOfYearInMonths() * 3));
+        int yearWeeks = (int) Math.floorMod(calcEm, lengthOfYearInMonths() * 3);
+        int weekDays = ((getDayOfMonth() - 1) % lengthOfWeek()) + 1;
+        int newMonth = yearWeeks / 3 + 1;
+        return resolvePrevious(newYear, newMonth, (yearWeeks % 3) * lengthOfWeek() + weekDays);
+    }
+
+    @Override
+    FrenchRepublicDate plusDays(long days) {
+        if (days % 10 == 0) {
+            return plusWeeks(days / 10);
+        }
+        return (FrenchRepublicDate) super.plusDays(days);
+    }
+
     @Override
     public FrenchRepublicDate minus(TemporalAmount amount) {
         return (FrenchRepublicDate) amount.subtractFrom(this);
@@ -418,8 +513,6 @@ public final class FrenchRepublicDate
 
     @Override
     public long toEpochDay() {
-        long year = (long) getProlepticYear();
-        long calendarEpochDay = (year * 365) + Math.floorDiv(year, 4) + (getDayOfYear() - 1);
-        return calendarEpochDay - 365 - getEpochDayDifference();
+        return this.epochDay;
     }
 }

--- a/src/test/java/org/threeten/extra/chrono/TestFrenchRepublicChronology.java
+++ b/src/test/java/org/threeten/extra/chrono/TestFrenchRepublicChronology.java
@@ -464,7 +464,7 @@ public class TestFrenchRepublicChronology {
     @Test
     public void test_Chronology_range() {
         assertEquals(FrenchRepublicChronology.INSTANCE.range(DAY_OF_WEEK), ValueRange.of(1, 10));
-        assertEquals(FrenchRepublicChronology.INSTANCE.range(DAY_OF_MONTH), ValueRange.of(1, 5, 30));
+        assertEquals(FrenchRepublicChronology.INSTANCE.range(DAY_OF_MONTH), ValueRange.of(1, 30));
         assertEquals(FrenchRepublicChronology.INSTANCE.range(DAY_OF_YEAR), ValueRange.of(1, 365, 366));
         assertEquals(FrenchRepublicChronology.INSTANCE.range(MONTH_OF_YEAR), ValueRange.of(1, 13));
     }

--- a/src/test/java/org/threeten/extra/chrono/TestFrenchRepublicChronology.java
+++ b/src/test/java/org/threeten/extra/chrono/TestFrenchRepublicChronology.java
@@ -54,6 +54,9 @@ import static java.time.temporal.ChronoUnit.MONTHS;
 import static java.time.temporal.ChronoUnit.WEEKS;
 import static java.time.temporal.ChronoUnit.YEARS;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
 
 import java.time.DateTimeException;
 import java.time.LocalDate;
@@ -63,13 +66,11 @@ import java.time.Period;
 import java.time.chrono.Chronology;
 import java.time.chrono.Era;
 import java.time.chrono.IsoEra;
-import java.time.temporal.IsoFields;
 import java.time.temporal.TemporalAdjusters;
 import java.time.temporal.TemporalField;
 import java.time.temporal.TemporalUnit;
 import java.time.temporal.UnsupportedTemporalTypeException;
 import java.time.temporal.ValueRange;
-import java.time.temporal.WeekFields;
 import java.util.List;
 
 import org.testng.Assert;
@@ -113,7 +114,6 @@ public class TestFrenchRepublicChronology {
             {FrenchRepublicDate.of(1, 1, 2), LocalDate.of(1792, 9, 23)},
             {FrenchRepublicDate.of(1, 1, 3), LocalDate.of(1792, 9, 24)},
             {FrenchRepublicDate.of(1, 1, 30), LocalDate.of(1792, 10, 21)},
-
             {FrenchRepublicDate.of(1, 4, 11), LocalDate.of(1792, 12, 31)},
             {FrenchRepublicDate.of(1, 4, 12), LocalDate.of(1793, 1, 1)},
             {FrenchRepublicDate.of(1, 6, 10), LocalDate.of(1793, 2, 28)},
@@ -203,8 +203,6 @@ public class TestFrenchRepublicChronology {
         assertEquals(FrenchRepublicDate.from(iso), french);
     }
 
-
-
     @Test(dataProvider = "samples")
     public void test_FrenchRepublicDate_chronology_dateEpochDay(FrenchRepublicDate frenchRepublic, LocalDate iso) {
         assertEquals(FrenchRepublicChronology.INSTANCE.dateEpochDay(iso.toEpochDay()), frenchRepublic);
@@ -241,7 +239,7 @@ public class TestFrenchRepublicChronology {
         assertEquals(LocalDate.from(frenchRepublic.plus(1, DAYS)), iso.plusDays(1));
         assertEquals(LocalDate.from(frenchRepublic.plus(35, DAYS)), iso.plusDays(35));
         assertEquals(LocalDate.from(frenchRepublic.plus(-1, DAYS)), iso.plusDays(-1));
-        assertEquals(LocalDate.from(frenchRepublic.plus(-60, DAYS)), iso.plusDays(-60));
+        assertEquals(LocalDate.from(frenchRepublic.plus(-59, DAYS)), iso.plusDays(-59));
     }
 
     @Test(dataProvider = "samples")
@@ -250,7 +248,7 @@ public class TestFrenchRepublicChronology {
         assertEquals(LocalDate.from(frenchRepublic.minus(1, DAYS)), iso.minusDays(1));
         assertEquals(LocalDate.from(frenchRepublic.minus(35, DAYS)), iso.minusDays(35));
         assertEquals(LocalDate.from(frenchRepublic.minus(-1, DAYS)), iso.minusDays(-1));
-        assertEquals(LocalDate.from(frenchRepublic.minus(-60, DAYS)), iso.minusDays(-60));
+        assertEquals(LocalDate.from(frenchRepublic.minus(-57, DAYS)), iso.minusDays(-57));
     }
 
     @Test(dataProvider = "samples")
@@ -369,22 +367,22 @@ public class TestFrenchRepublicChronology {
             {1, 10, 30},
             {1, 11, 30},
             {1, 12, 30},
-            {1, 13, 5},
+            {1, 13, 0},
 
-            {1, 13, 5},
-            {2, 13, 5},
-            {3, 13, 6},
-            {4, 13, 5},
-            {5, 13, 5},
-            {6, 13, 5},
-            {7, 13, 6},
-            {8, 13, 5},
-            {9, 13, 5},
-            {10, 13, 5},
-            {11, 13, 6},
-            {12, 13, 5},
-            {13, 13, 5},
-            {14, 13, 5},
+            {1, 13, 0},
+            {2, 13, 0},
+            {3, 13, 0},
+            {4, 13, 0},
+            {5, 13, 0},
+            {6, 13, 0},
+            {7, 13, 0},
+            {8, 13, 0},
+            {9, 13, 0},
+            {10, 13, 0},
+            {11, 13, 0},
+            {12, 13, 0},
+            {13, 13, 0},
+            {14, 13, 0},
         };
     }
 
@@ -489,15 +487,15 @@ public class TestFrenchRepublicChronology {
             {1, 10, 23, DAY_OF_MONTH, 1, 30},
             {1, 11, 23, DAY_OF_MONTH, 1, 30},
             {1, 12, 23, DAY_OF_MONTH, 1, 30},
-            {1, 13, 2, DAY_OF_MONTH, 1, 5},
+            {1, 13, 2, DAY_OF_MONTH, 0, 0},
             {1, 1, 23, DAY_OF_YEAR, 1, 365},
             {1, 1, 23, ALIGNED_WEEK_OF_MONTH, 1, 3},
             {1, 12, 23, ALIGNED_WEEK_OF_MONTH, 1, 3},
-            {1, 13, 2, ALIGNED_WEEK_OF_MONTH, 1, 1},
+            {1, 13, 2, ALIGNED_WEEK_OF_MONTH, 0, 0},
 
-            {3, 13, 2, DAY_OF_MONTH, 1, 6},
+            {3, 13, 2, DAY_OF_MONTH, 0, 0},
             {3, 13, 2, DAY_OF_YEAR, 1, 366},
-            {3, 13, 2, ALIGNED_WEEK_OF_MONTH, 1, 1},
+            {3, 13, 2, ALIGNED_WEEK_OF_MONTH, 0, 0},
         };
     }
 
@@ -525,7 +523,7 @@ public class TestFrenchRepublicChronology {
             {1, 6, 8, ALIGNED_DAY_OF_WEEK_IN_YEAR, 8},
             {1, 6, 8, ALIGNED_WEEK_OF_YEAR, 16},
             {1, 6, 8, MONTH_OF_YEAR, 6},
-            {1, 6, 8, PROLEPTIC_MONTH, 13 + 6 - 1},
+            {1, 6, 8, PROLEPTIC_MONTH, 12 + 6 - 1},
             {1, 6, 8, YEAR, 1},
             {1, 6, 8, ERA, 1},
 
@@ -567,13 +565,13 @@ public class TestFrenchRepublicChronology {
             {1, 5, 26, MONTH_OF_YEAR, 7, 1, 7, 26},
             {1, 5, 26, MONTH_OF_YEAR, 5, 1, 5, 26},
 
-            {1, 5, 26, PROLEPTIC_MONTH, 3 * 13 + 3 - 1, 3, 3, 26},
-            {1, 5, 26, PROLEPTIC_MONTH, 4 * 13 + 5 - 1, 4, 5, 26},
+            {1, 5, 26, PROLEPTIC_MONTH, 3 * 12 + 3 - 1, 3, 3, 26},
+            {1, 5, 26, PROLEPTIC_MONTH, 4 * 12 + 5 - 1, 4, 5, 26},
             {1, 5, 26, YEAR, 2, 2, 5, 26},
             {1, 5, 26, YEAR, 3, 3, 5, 26},
             {1, 5, 26, YEAR_OF_ERA, 2, 2, 5, 26},
             {1, 5, 26, YEAR_OF_ERA, 3, 3, 5, 26},
-            //{1, 5, 26, ERA, 0, -1, 5, 26},
+            {1, 5, 26, ERA, 0, 0, 5, 26},
             {1, 5, 26, ERA, 1, 1, 5, 26},
 
             {1, 3, 30, MONTH_OF_YEAR, 13, 1, 13, 5},
@@ -608,9 +606,9 @@ public class TestFrenchRepublicChronology {
 
     @Test
     public void test_adjust2() {
-        FrenchRepublicDate base = FrenchRepublicDate.of(3, 13, 2);
+        FrenchRepublicDate base = FrenchRepublicDate.of(3, 12, 2);
         FrenchRepublicDate test = base.with(TemporalAdjusters.lastDayOfMonth());
-        assertEquals(test, FrenchRepublicDate.of(3, 13, 6));
+        assertEquals(test, FrenchRepublicDate.of(3, 12, 30));
     }
 
     //-----------------------------------------------------------------------
@@ -658,12 +656,14 @@ public class TestFrenchRepublicChronology {
             {1, 5, 26, 0, WEEKS, 1, 5, 26},
             {1, 5, 26, 3, WEEKS, 1, 6, 26},
             {1, 5, 26, -5, WEEKS, 1, 4, 6},
-            {1, 12, 25, 1, WEEKS, 1, 13, 5},
-            //{1, 12, 25, 2, WEEKS, 2, 1, 5},
-            //{1, 12, 25, 3, WEEKS, 2, 2, 5},
+            {1, 12, 25, 1, WEEKS, 2, 1, 5},
+            {1, 12, 25, 2, WEEKS, 2, 1, 15},
+            {1, 12, 25, 3, WEEKS, 2, 1, 25},
+            {1, 13, 5, 72, WEEKS, 3, 13, 5},
             {1, 5, 26, 0, MONTHS, 1, 5, 26},
             {1, 5, 26, 3, MONTHS, 1, 8, 26},
-            {2, 5, 5, -5, MONTHS, 1, 13, 5},
+            {2, 5, 5, -5, MONTHS, 1, 12, 5},
+            {1, 13, 5, 12, MONTHS, 2, 13, 5},
             {1, 5, 26, 0, YEARS, 1, 5, 26},
             {1, 5, 26, 3, YEARS, 4, 5, 26},
             {13, 5, 26, -5, YEARS, 8, 5, 26},
@@ -676,12 +676,13 @@ public class TestFrenchRepublicChronology {
             {1, 5, 26, 0, MILLENNIA, 1, 5, 26},
             {1, 5, 26, 3, MILLENNIA, 3001, 5, 26},
             {5002, 5, 26, -5, MILLENNIA, 5002 - 5000, 5, 26},
-            //{2, 5, 26, -1, ERAS, -1, 5, 26},
+            {2, 5, 26, -1, ERAS, -1, 5, 26},
         };
     }
 
     @Test(dataProvider = "plus")
-    public void test_plus_TemporalUnit(int year, int month, int dom,
+    public void test_plus_TemporalUnit(
+            int year, int month, int dom,
             long amount, TemporalUnit unit,
             int expectedYear, int expectedMonth, int expectedDom) {
         assertEquals(FrenchRepublicDate.of(year, month, dom).plus(amount, unit), FrenchRepublicDate.of(expectedYear, expectedMonth, expectedDom));
@@ -697,7 +698,7 @@ public class TestFrenchRepublicChronology {
 
     @Test(expectedExceptions = UnsupportedTemporalTypeException.class)
     public void test_plus_TemporalUnit_unsupported() {
-        FrenchRepublicDate.of(2012, 6, 30).plus(0, MINUTES);
+        FrenchRepublicDate.of(2012, 6, 30).plus(1, MINUTES);
     }
 
     //-----------------------------------------------------------------------
@@ -783,14 +784,15 @@ public class TestFrenchRepublicChronology {
         FrenchRepublicDate c = FrenchRepublicDate.of(1, 2, 3);
         FrenchRepublicDate d = FrenchRepublicDate.of(2, 1, 3);
 
-        assertEquals(a1.equals(a1), true);
-        assertEquals(a1.equals(a2), true);
-        assertEquals(a1.equals(b), false);
-        assertEquals(a1.equals(c), false);
-        assertEquals(a1.equals(d), false);
+        assertNotNull(a1);
+        assertTrue(a1.equals(a1));
+        assertTrue(a1.equals(a2));
+        assertFalse(a1.equals(b));
+        assertFalse(a1.equals(c));
+        assertFalse(a1.equals(d));
 
-        assertEquals(a1.equals(null), false);
-        assertEquals(a1.equals(""), false);
+        assertFalse(a1.equals(null));
+        assertFalse(a1.equals(""));
 
         assertEquals(a1.hashCode(), a2.hashCode());
     }
@@ -803,6 +805,7 @@ public class TestFrenchRepublicChronology {
         return new Object[][] {
             {FrenchRepublicDate.of(1, 1, 1), "French Republican REPUBLICAN 1-01-01"},
             {FrenchRepublicDate.of(14, 13, 5), "French Republican REPUBLICAN 14-13-05"},
+            {FrenchRepublicDate.of(0, 5, 5), "French Republican BEFORE_REPUBLICAN 1-05-05"},
         };
     }
 


### PR DESCRIPTION
New empty ValueRange for ranges on supplementary days involving weeks and month calculation.
Epoch day is calculated in the constructor instead of dynamically, make it immutable.
Corrected hopefully the last reference to "French revolution" in favour of "French Republican".
Corrected/fixed all commented cases in the test class.
Does not depend on AbstractNile* classes anymore.